### PR TITLE
Fix RF cards' tags

### DIFF
--- a/src/app/common/components/modals/Tags/TagsSliderModal/TagsSliderModal.component.tsx
+++ b/src/app/common/components/modals/Tags/TagsSliderModal/TagsSliderModal.component.tsx
@@ -38,7 +38,7 @@ const TagsSliderModal = ({ streetCodeid, activeTagBlock, setActiveTagId }: Props
                         focusOnSelect
                     >
                         {getTagArray?.map((tag) => (
-                            <div>
+                            <div key={tag.id}>
                                 <Button
                                     className="tagModalItem"
                                     onClick={() => {
@@ -54,7 +54,7 @@ const TagsSliderModal = ({ streetCodeid, activeTagBlock, setActiveTagId }: Props
                 ) : (
                     <div>
                         {getTagArray?.map((tag) => (
-                            <div>
+                            <div key={tag.id}>
                                 <Button
                                     className="tagModalItem"
                                     onClick={() => {

--- a/src/features/StreetcodePage/RelatedFiguresBlock/RelatedFigureItem/RelatedFigureItem.component.tsx
+++ b/src/features/StreetcodePage/RelatedFiguresBlock/RelatedFigureItem/RelatedFigureItem.component.tsx
@@ -1,16 +1,12 @@
 /* eslint-disable complexity */
 import './RelatedFigureItem.styles.scss';
 
-import { useState } from 'react';
-import { useAsync } from '@hooks/stateful/useAsync.hook';
 import RelatedFigure from '@models/streetcode/related-figure.model';
 import useMobx, { useModalContext } from '@stores/root-store';
 
-import ImagesApi from '@/app/api/media/images.api';
 import useWindowSize from '@/app/common/hooks/stateful/useWindowSize.hook';
 import base64ToUrl from '@/app/common/utils/base64ToUrl.utility';
 import { relatedFiguresLeaveEvent, relatedFiguresTagsEvent } from '@/app/common/utils/googleAnalytics.unility';
-import Image from '@/models/media/image.model';
 
 interface Props {
     relatedFigure: RelatedFigure;
@@ -26,7 +22,6 @@ const RelatedFigureItem = ({ relatedFigure, setActiveTagId, filterTags = true, h
     const { tagsStore: { getTagArray } } = useMobx();
     const { modalStore } = useModalContext();
     const { setModal, modalsState: { tagsList } } = modalStore;
-
     const windowsize = useWindowSize();
 
     const handleClick = () => {
@@ -34,9 +29,7 @@ const RelatedFigureItem = ({ relatedFigure, setActiveTagId, filterTags = true, h
             setModal('relatedFigureItem', id, true);
         }
     };
-
     const totalLength: number = tags.reduce((acc, str) => acc + str.title.length, 0);
-
     return (
         <>
             {windowsize.width > 1024 && (

--- a/src/features/StreetcodePage/RelatedFiguresBlock/RelatedFigureItem/RelatedFigureItem.styles.scss
+++ b/src/features/StreetcodePage/RelatedFiguresBlock/RelatedFigureItem/RelatedFigureItem.styles.scss
@@ -72,7 +72,8 @@
 .relatedTagList {
     @include mut.sized($width: 100%);
     visibility: hidden;
-
+    overflow: hidden;
+    max-height: 71px;
     @include mut.flexed($align-items: center, $gap: 5px, $wrap: wrap);
     padding: 7px 23px 0px;
 


### PR DESCRIPTION
Added max-height and overflow props to related tag list class, so it would not display tags below the second row