### PR TITLE
Fix RF tag modal.

### DIFF
--- a/src/app/stores/streetcodes-bytag-store.ts
+++ b/src/app/stores/streetcodes-bytag-store.ts
@@ -1,4 +1,5 @@
 import { makeAutoObservable } from 'mobx';
+import ImagesApi from '@api/media/images.api';
 import relatedFiguresApi from '@api/streetcode/related-figure.api';
 import RelatedFigure from '@models/streetcode/related-figure.model';
 
@@ -24,7 +25,11 @@ export default class StreetcodesByTagStore {
 
     public fetchRelatedFiguresByTagId = async (tagId: number) => {
         try {
-            this.setInternalRelatedFiguresMap = await relatedFiguresApi.getByTagId(tagId);
+            this.setInternalRelatedFiguresMap = await relatedFiguresApi.getByTagId(tagId).then((res) => Promise.all(res.map(async (figure) => {
+                figure.image = await ImagesApi.getById(figure.imageId);
+                figure.tags = [];
+                return figure;
+            })));
         } catch (error: unknown) { /* empty */ }
     };
 }


### PR DESCRIPTION
dev
## Git
https://github.com/ita-social-projects/StreetCode_Client/issues/391


## Code reviewers

- [ ] @NadiaKishchuk 
- [ ] @Katerix 
- [ ] @MementoMorj 
- [ ] @Tysyatsky 
- [ ] @Dobriyr 
- [ ] @ormykhalyshyn 
- [x] @MaksBrat 

### Second Level Review

- [ ] @LanchevychMaxym 

## Summary of issue

The modal tag not includes images of related figure cards and includes the text of the tags.

## Summary of change

Included in figures modal image by calling the ImageAPI and removed tags' text.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
