### PR TITLE
401 adminchronology block when the admin add more than 50 characters to the context field all text is erased

### DIFF
--- a/src/features/AdminPage/NewStreetcode/TimelineBlock/NewTimelineModal/NewTimelineModal.component.tsx
+++ b/src/features/AdminPage/NewStreetcode/TimelineBlock/NewTimelineModal/NewTimelineModal.component.tsx
@@ -116,7 +116,6 @@ const NewTimelineModal: React.FC<NewTimelineModalProps> = observer(({ timelineIt
         setTagInput('');
         setErrorMessage('');
         onChange('historicalContexts', selectedContext.current);
-        // onChange('historicalContexts', tagInput);
     };
 
     const onContextDeselect = (value: string) => {
@@ -129,18 +128,17 @@ const NewTimelineModal: React.FC<NewTimelineModalProps> = observer(({ timelineIt
         onChange('historicalContexts', selectedContext.current);
     };
 
-    const [lastTagInput, setLastTagInput] = useState('');
-
-    const onContextKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-        const { value } = event.currentTarget;
-        setTagInput(value);
-        setLastTagInput(value);
-
-        if (value.length + 1 > maxContextLength) {
-            setErrorMessage(`Довжина не повинна перевищувати ${maxContextLength} символів`);
-            setTagInput(lastTagInput);
-        } else {
-            setErrorMessage('');
+    const onContextKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+        const { value } = e.currentTarget;
+        if (e.key === 'Enter') {
+            if (value.length > maxContextLength) {
+                setErrorMessage(`Довжина не повинна перевищувати ${maxContextLength} символів`);
+                e.preventDefault();
+                e.stopPropagation();
+            } else {
+                setTagInput(value);
+                setErrorMessage('');
+            }
         }
     };
 

--- a/src/features/AdminPage/NewStreetcode/TimelineBlock/NewTimelineModal/NewTimelineModal.component.tsx
+++ b/src/features/AdminPage/NewStreetcode/TimelineBlock/NewTimelineModal/NewTimelineModal.component.tsx
@@ -39,6 +39,7 @@ const NewTimelineModal: React.FC<NewTimelineModalProps> = observer(({ timelineIt
     const [errorMessage, setErrorMessage] = useState<string>('');
     const [tagInput, setTagInput] = useState('');
     const maxContextLength = 50;
+    const getErrorMessage = (maxLength: number = maxContextLength) => `Довжина не повинна перевищувати ${maxLength} символів`;
 
     useEffect(() => {
         if (timelineItem && open) {
@@ -92,7 +93,7 @@ const NewTimelineModal: React.FC<NewTimelineModalProps> = observer(({ timelineIt
         if (index < 0) {
             if (value.length > maxContextLength) {
                 form.setFieldValue('historicalContexts', selectedContext.current.map((c) => c.title));
-                setErrorMessage('');
+                setErrorMessage(getErrorMessage());
                 return;
             }
             const newItem: HistoricalContextUpdate = {
@@ -132,7 +133,7 @@ const NewTimelineModal: React.FC<NewTimelineModalProps> = observer(({ timelineIt
         const { value } = e.currentTarget;
         if (e.key === 'Enter') {
             if (value.length > maxContextLength) {
-                setErrorMessage(`Довжина не повинна перевищувати ${maxContextLength} символів`);
+                setErrorMessage(getErrorMessage());
                 e.preventDefault();
                 e.stopPropagation();
             } else {


### PR DESCRIPTION
dev
## JIRA

* [Main JIRA ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)


## Code reviewers

- [ ] @ita-social-projects/lv-734-02-streetcode 
- [ ] @ita-social-projects/lv-734-03-streetcode 
- [ ] @ita-social-projects/lv-734-04-streetcode 

## Summary of issue

ToDo

## Summary of change

ToDo

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
