### PR TITLE
configure backend link as env variable at runtime

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,3 @@
 REACT_APP_BACKEND_URL=https://localhost:5001/api
 REACT_APP_TEMPVAL=tempval
+API_URL=https://best.api.ever.com

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,11 @@ COPY --from=build /app/dist /usr/share/nginx/html
 RUN rm /etc/nginx/conf.d/default.conf
 COPY nginx/nginx.conf /etc/nginx/conf.d
 EXPOSE 3000
-ENTRYPOINT ["nginx", "-g", "daemon off;"]
+
+WORKDIR /usr/share/nginx/html
+COPY ./env.sh .
+COPY .env .
+RUN apk add --no-cache bash
+RUN chmod +x env.sh
+
+CMD ["/bin/bash", "-c", "/usr/share/nginx/html/env.sh && nginx -g \"daemon off;\""]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,52 @@
+services:
+  frontend:
+    image: saymolet/streetcode_client:latest
+    pull_policy: always
+    ports:
+      - "80:3000"
+    expose:
+      - "3000"
+    healthcheck:
+      test: curl --fail http://localhost || exit 1
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    environment:
+      API_URL: ${ENV_API_BACKEND}
+  backend:
+    image: saymolet/streetcode:latest
+    pull_policy: always
+    expose:
+      - "80"
+    ports:
+    - "5000:80"
+    environment:
+      STREETCODE_ConnectionStrings__DefaultConnection: ${DB_CONNECTION_STRING}
+      STREETCODE_Blob__BlobStoreKey: ${BLOB_STORAGE_KEY}
+      STREETCODE_Blob__BlobStorePath: /mnt/data/
+      STREETCODE_Instagram__InstagramID: ${INSTAGRAM_ID}
+      STREETCODE_Instagram__InstagramToken: ${INSTAGRAM_TOKEN}
+      STREETCODE_Payment__Token: ${PAYMENT_TOKEN}
+      STREETCODE_CORS__AllowedOrigins: '["*"]'
+      STREETCODE_CORS__AllowedHeaders: '["*"]'
+      STREETCODE_CORS__AllowedMethods: '["*"]'
+      STREETCODE_CORS__PreflightMaxAge: 1
+      STREETCODE_IPRATELIMITING__GENERALRULES__0__LIMIT: 500
+    volumes:
+      - type: bind
+        source: /imagestorage
+        target: /mnt/data
+    healthcheck:
+      test: curl --fail http://localhost/api/partners/getAll || exit 1
+      interval: 30s
+      timeout: 10s
+      retries: 5
+volumes:
+  backend:
+networks:
+  backend:
+    external:
+      name: backend
+  frontend:
+    external:
+      name: frontend

--- a/env.sh
+++ b/env.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Recreate config file
+rm -rf ./env-config.js
+touch ./env-config.js
+
+# Add assignment
+echo "window._env_ = {" >> ./env-config.js
+
+# Read each line in .env file
+# Each line represents key=value pairs
+while read -r line || [[ -n "$line" ]];
+do
+  # Split env variables by character `=`
+  if printf '%s\n' "$line" | grep -q -e '='; then
+    varname=$(printf '%s\n' "$line" | sed -e 's/=.*//')
+    varvalue=$(printf '%s\n' "$line" | sed -e 's/^[^=]*=//')
+  fi
+
+  # Read value of current variable if exists as Environment variable
+  value=$(printf '%s\n' "${!varname}")
+  # Otherwise use value from .env file
+  [[ -z $value ]] && value=${varvalue}
+
+  # Append configuration property to JS file
+  echo "  $varname: \"$value\"," >> ./env-config.js
+done < .env
+
+echo "}" >> ./env-config.js

--- a/public/index.html
+++ b/public/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="uk">
 <head>
+  <script src="env-config.js"></script>
   <meta charset="utf-8" />
   <link rel="icon" href="favicon.ico" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/src/app/api/agent.api.ts
+++ b/src/app/api/agent.api.ts
@@ -7,7 +7,7 @@ import FRONTEND_ROUTES from '../common/constants/frontend-routes.constants';
 import UserLoginStore from '../stores/user-login-store';
 
 axios.defaults.baseURL = process.env.NODE_ENV === 'development'
-    ? 'https://localhost:5001/api' : 'http://185.230.138.173:5000/api';
+    ? 'https://localhost:5001/api' : window._env_.API_URL;
 
 axios.interceptors.response.use(
     async (response) => response,


### PR DESCRIPTION
dev
## JIRA

Now we can configure API_URL link at docker compose runtime as an environmental variable. Do not use latest images from saymolet/streetcode*:latest. They are configured with stage link and https. In near future stage and production environments will only have one or the other: dns+https or just plain IP address as access points. 

Street Code Docker Hub repo will host all future images. 

![KOJdYnS](https://github.com/ita-social-projects/StreetCode_Client/assets/101016860/1e6992d4-1a93-4856-bbda-72536425934a)


* [Main JIRA ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

ToDo

## Summary of change

ToDo

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
