### PR TITLE
Streetcode link higlighting

### DIFF
--- a/src/features/StreetcodePage/MainBlock/BreadCrumb/BreadCrumb.styles.scss
+++ b/src/features/StreetcodePage/MainBlock/BreadCrumb/BreadCrumb.styles.scss
@@ -5,9 +5,6 @@
 
 .activeLink {
   font-weight: 600;
-  &:hover{
-    font-weight: 1000;
-  }
 }
 
 .ant-breadcrumb{


### PR DESCRIPTION
The "СТРІТКОДИ" is not supposed to be highlighted when mouse hovers:
![image](https://github.com/ita-social-projects/StreetCode_Client/assets/92052144/48cbf21e-1c9b-4cf8-b531-8ec7d1b4b98c)
![image_2023-08-15_19-31-53](https://github.com/ita-social-projects/StreetCode_Client/assets/92052144/750077c8-9314-4ab8-9578-33a70feab9b1)

## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

ToDo

## Summary of change

ToDo

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
