### PR TITLE
Fix shadows

### DIFF
--- a/src/app/common/components/ScrollToTopBtn/ScrollToTopBtn.styles.scss
+++ b/src/app/common/components/ScrollToTopBtn/ScrollToTopBtn.styles.scss
@@ -13,7 +13,7 @@
 
   &:hover {
     cursor: pointer;
-    @include vnd.vendored(filter, '#{c.$hovered-btn-filter-color}');
+    box-shadow: c.$hovered-btn-box-shadow;
   }
 }
 
@@ -33,13 +33,13 @@
 
   @include vnd.vendored(animation, 'btnOpacity 1s ease-in-out');
   @include vnd.vendored(transition, 'filter .5s ease');
-  
+
   z-index: 4;
   border: 3px solid c.$accented-red-color;
 
   &:hover {
     cursor: pointer;
-    @include vnd.vendored(filter, '#{c.$hovered-btn-filter-color}');
+    box-shadow: c.$hovered-btn-box-shadow;
   }
 }
 

--- a/src/app/common/components/modals/Donates/DonatesModal.styles.scss
+++ b/src/app/common/components/modals/Donates/DonatesModal.styles.scss
@@ -25,7 +25,7 @@
     .ant-modal-close {
       @include mut.positioned-as(absolute, $left: 94%, $top: -27px);
       @include mut.circular(80px, c.$pure-white-color);
-      filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25));
+      box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);(0px 4px 4px rgba(0, 0, 0, 0.25));
 
       &:hover {
         background-color: c.$modal-hover-color;
@@ -116,7 +116,8 @@
       border-radius: 15px !important;
       border: 3px solid c.$dark-red-color;
       @include vnd.vendored(transition, 'background-color .75s ease');
-      filter: drop-shadow(0px 2px 4px rgba(0, 0, 0, 0.19)); 
+      box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.19);
+
 
       > span {
         @include vnd.vendored(transition, 'color .75s ease');
@@ -148,20 +149,20 @@
       border: none;
       display: flex;
       align-items: center;
-      
-      
+
+
       .ant-checkbox-input {
         @include mut.sized(24px, 24px);
       }
-      
+
       span{
         display: inline-block;
         vertical-align:baseline;
-                   
+
         .ant-checkbox-inner {
           @include mut.sizedImportant(24px, 24px);
         }
-  
+
         &:last-child {
           @include mut.with-font(ft.$roboto-font, $font-size: 15px, $font-weight: 300);
 
@@ -284,7 +285,7 @@
       }
       .donatesBtnContainer{
         @include mut.sized(308px, 100%);
-        
+
         gap: 0;
         > * {
           width: f.pxToRem(100px) !important;
@@ -314,7 +315,7 @@
       .donatesInputContainer{
         @include mut.sized(100%, 28px);
         margin: 16px;
-        
+
         >.checkbox-borderline {
           display: flex;
           overflow: visible !important;
@@ -322,10 +323,10 @@
           > span{
             display: inline-block;
             vertical-align: middle;
-      
+
             &:last-child {
               @include mut.with-font(ft.$roboto-font, $font-size: 12px, $font-weight: 500);
-            
+
               height: f.pxToRem(28px);
               padding-top: f.pxToRem(2px);
               font-style: normal;

--- a/src/app/common/components/modals/Donates/DonatesModal.styles.scss
+++ b/src/app/common/components/modals/Donates/DonatesModal.styles.scss
@@ -25,7 +25,7 @@
     .ant-modal-close {
       @include mut.positioned-as(absolute, $left: 94%, $top: -27px);
       @include mut.circular(80px, c.$pure-white-color);
-      box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);(0px 4px 4px rgba(0, 0, 0, 0.25));
+      box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
 
       &:hover {
         background-color: c.$modal-hover-color;

--- a/src/app/common/components/modals/HeaderLogin/HeaderLoginModal.styles.scss
+++ b/src/app/common/components/modals/HeaderLogin/HeaderLoginModal.styles.scss
@@ -18,7 +18,7 @@
     .ant-modal-close {
       @include mut.positioned-as(absolute, $left: 89%, $top: -25px);
       @include mut.circular(80px, c.$pure-white-color);
-      box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);(0px 4px 4px rgba(0, 0, 0, 0.25));
+      box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
 
       &:hover {
         background-color: c.$modal-hover-color;

--- a/src/app/common/components/modals/HeaderLogin/HeaderLoginModal.styles.scss
+++ b/src/app/common/components/modals/HeaderLogin/HeaderLoginModal.styles.scss
@@ -18,7 +18,7 @@
     .ant-modal-close {
       @include mut.positioned-as(absolute, $left: 89%, $top: -25px);
       @include mut.circular(80px, c.$pure-white-color);
-      filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25));
+      box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);(0px 4px 4px rgba(0, 0, 0, 0.25));
 
       &:hover {
         background-color: c.$modal-hover-color;

--- a/src/app/common/components/modals/ListenText/ListenText.styles.scss
+++ b/src/app/common/components/modals/ListenText/ListenText.styles.scss
@@ -15,7 +15,7 @@
     border: 2px solid #DB3424;
 
     z-index: 1000;
-    @include vnd.vendored(filter, 'drop-shadow(0 2px 15px rgba(163, 163, 163, 0.25))');
+    box-shadow: 0 2px 15px rgba(163, 163, 163, 0.25);
 }
 
 .fadeInAnimation {
@@ -58,10 +58,10 @@
           }
       }
     }
-  
+
 }
 @media screen and (max-width: 1024px){
-   
+
     .buttonContainer {
         margin-right: f.pxToRem(15px);
     }

--- a/src/app/common/components/modals/Partners/PartnersModal.styles.scss
+++ b/src/app/common/components/modals/Partners/PartnersModal.styles.scss
@@ -8,10 +8,10 @@
     .ant-input-affix-wrapper, .ant-input-affix-wrapper-focused{
         border: none;
         box-shadow: none !important;
-    }  
+    }
     width: f.pxToRem(1012px) !important;
     height: f.pxToRem(460px);
-    
+
     &.ant-modal {
       .ant-modal-content {
         @include mut.full-rounded(20px, $overflow: visible);
@@ -19,12 +19,12 @@
         padding: f.pxToRem(24px)  f.pxToRem(40px);
         box-shadow: 0 7px 11px 2px rgba(0, 0, 0, 0.25);
       }
-  
+
       .ant-modal-close {
         @include mut.positioned-as(absolute, $left: 94%, $top: -25px);
         @include mut.circular(80px, c.$pure-white-color);
-        
-        filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25));
+
+        box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);(0px 4px 4px rgba(0, 0, 0, 0.25));
         .ant-modal-close-x{
           font-size: 24px;
         }
@@ -35,7 +35,7 @@
     }
 
     .partnersModalContent{
-        .formContainer{    
+        .formContainer{
             text-align: center;
 
             .formTitle{
@@ -46,14 +46,14 @@
 
             margin-bottom: f.pxToRem(32px);
             }
-            
+
             .contactForm{
                 @include mut.flexed($direction: column, $gap: 24px);
-        
+
                 textarea{
                     resize: none;
-                    outline: none;     
-                    height: f.pxToRem(140px);     
+                    outline: none;
+                    height: f.pxToRem(140px);
                 }
                 textarea, input:focus{
                     outline: none;
@@ -62,14 +62,14 @@
                     width: 100%;
                     padding: f.pxToRem(12px) f.pxToRem(24px);
                     border: 1px solid #D3CDCA;
-                    @include mut.full-rounded(14px); 
+                    @include mut.full-rounded(14px);
                     @include mut.with-font($font-family: ft.$roboto-font, $font-weight: 300, $font-size: 20px);
                     line-height: 27px;
-                    
+
                     overflow: auto !important;
                     // color: #C4C4C4;
                 }
-            
+
                 .textareaBlock{
                     position: relative;
                     .amountSymbols{
@@ -79,7 +79,7 @@
                         color: #C4C4C4;
                     }
                 }
-            
+
                 .ant-input:hover, .ant-input:focus{
                     border: 1px solid #D3CDCA;
                     box-shadow: none;
@@ -101,24 +101,24 @@
                 .ant-form-item .ant-form-item-explain-error {
                     display: none;
                 }
-        
+
                 button{
                     @include mut.with-font($font-family: ft.$roboto-font, $font-weight: 500, $font-size: 20px);
                     line-height: 23px;
-                    color: #FFFFFF; 
-            
+                    color: #FFFFFF;
+
                     padding: f.pxToRem(25px) f.pxToRem(56px);
                     height: 100%;
                     background-color: #E04031;
                     box-shadow: 0px 4px 4px rgba(219, 52, 36, 0.18);
                     @include mut.full-rounded(14px);
-                    border: none; 
-                    cursor: pointer;      
+                    border: none;
+                    cursor: pointer;
                 }
-        
+
                 .required-input {
                     position: relative;
-                }         
+                }
                 .required-input::before {
                     content: '*';
                     position: absolute;
@@ -128,17 +128,17 @@
                     color: red;
                     font-size: 20px;
                 }
-                
+
                 .captchaBlock{
-                    @include mut.flexed($direction: column, $justify-content: center, $align-items: center);     
-                } 
+                    @include mut.flexed($direction: column, $justify-content: center, $align-items: center);
+                }
             }
         }
     }
 }
 
 @media screen and (max-width: 1024px){
-    .partnersModal {       
+    .partnersModal {
         &.ant-modal {
             .ant-modal-content {
                 @include mut.full-rounded(24px, $overflow: visible);
@@ -154,7 +154,7 @@
     .partnersModalContent{
         .formContainer{
             width: 100%;
-            
+
             .formTitle{
                 @include mut.with-font($font-family: ft.$closer-text-font, $font-weight: 500, $font-size: 14px);
                 text-align: left;
@@ -172,7 +172,7 @@
                     width: 100%;
                     padding: f.pxToRem(15px) 0 !important;
                 }
-        
+
                 textarea, input{
                     @include mut.with-font($font-family: ft.$roboto-font, $font-weight: 300, $font-size: 16px);
                     line-height: 21px;
@@ -182,16 +182,16 @@
                     top: f.pxToRem(110px);
                 }
             }
-        }  
-    } 
-}  
+        }
+    }
+}
 
 @media screen and (max-width: 480px) {
     .formTitle{
-        text-align: center; 
-    }      
-} 
-  
+        text-align: center;
+    }
+}
+
 .iconSize {
     @include mut.sized(80px, 78px);
     padding: 31%;

--- a/src/app/common/components/modals/Partners/PartnersModal.styles.scss
+++ b/src/app/common/components/modals/Partners/PartnersModal.styles.scss
@@ -24,7 +24,7 @@
         @include mut.positioned-as(absolute, $left: 94%, $top: -25px);
         @include mut.circular(80px, c.$pure-white-color);
 
-        box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);(0px 4px 4px rgba(0, 0, 0, 0.25));
+        box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
         .ant-modal-close-x{
           font-size: 24px;
         }

--- a/src/app/common/components/modals/RelatedFigures/RelatedFigureItemModal.styles.scss
+++ b/src/app/common/components/modals/RelatedFigures/RelatedFigureItemModal.styles.scss
@@ -21,10 +21,10 @@ $modal-width: 278px;
             background-color: c.$accented-gray-color;
 
             display: block;
-        
+
             @include vnd.vendored(transition, 'all .5s ease');
 
-            .figureSlideImage {    
+            .figureSlideImage {
                 @include mut.sized($width: $modal-width - 6px, $height: 273px);
                 background-size: 100%;
                 background-repeat: no-repeat;
@@ -33,25 +33,25 @@ $modal-width: 278px;
             .figureSlideText {
                 @include mut.sized($width: $modal-width, $height: 69px);
                 @include mut.rounded($bottom-left: 29px, $bottom-right: 29px);
-            
+
                 background-color: c.$dark-red-color;
-            
+
                 .heading {
                     @include mut.sized($width: 100%, $height: 69px);
-                    
+
                     display: flex;
                     flex-direction: column;
                     justify-content: center;
-                    
+
                     .aliasText {
                         line-height: pxToRem(13.2px);
                         font-size: 10px;
                     }
-            
+
                     p {
                         @include mut.truncated($line-num: 2);
                         @include mut.rem-padded($left: 0px, $right: 0px, $top: 0px);
-            
+
                         @include mut.with-font($font-family: f.$closer-text-font, $font-weight: 500);
                         line-height: pxToRem(18.48px);
                         font-size: 14px;
@@ -91,7 +91,7 @@ $modal-width: 278px;
             @include mut.positioned-as(absolute, $left: 88%, $top: -15px);
             @include mut.circular(40px, c.$pure-white-color);
 
-            filter: drop-shadow(0px 2.0241px 2.0241px rgba(0, 0, 0, 0.25));
+            box-shadow: 0px 2.03px 2.03px rgba(0, 0, 0, 0.25);
             display: inline;
 
             &:hover {

--- a/src/app/common/components/modals/Survey/SurveyModal.styles.scss
+++ b/src/app/common/components/modals/Survey/SurveyModal.styles.scss
@@ -8,7 +8,7 @@ $StbgImg: '@assets/images/donates/bgStrLogo.png';
 .surveyModal {
   width: f.pxToRem(832px) !important;
   height: f.pxToRem(414px);
- 
+
   display: flex;
   justify-content: center;
   align-items: center;
@@ -18,7 +18,7 @@ $StbgImg: '@assets/images/donates/bgStrLogo.png';
       height: inherit;
       @include mut.flex-centered($direction: column);
       @include mut.full-rounded(30px, $overflow: visible);
-      
+
       @include mut.bg-image($StbgImg, 18%, no-repeat);
       background-position: center;
       padding: 0 !important;
@@ -26,10 +26,10 @@ $StbgImg: '@assets/images/donates/bgStrLogo.png';
     }
 
     .ant-modal-close {
-      
+
       @include mut.positioned-as(absolute, $left: 94%, $top: -27px);
       @include mut.circular(80px, c.$pure-white-color);
-      filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25));
+      box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
 
       &:hover {
         background-color: c.$modal-hover-color;
@@ -48,7 +48,7 @@ $StbgImg: '@assets/images/donates/bgStrLogo.png';
   @include mut.flex-centered($direction: column);
   @include mut.rem-margined(80px, 20px, 40px, 20px);
   text-align: center;
-  
+
   > h1 {
     color: c.$pure-black-color;
     @include mut.with-font(ft.$closer-text-font, $font-size: 25px, $font-weight: 500);
@@ -71,7 +71,7 @@ $StbgImg: '@assets/images/donates/bgStrLogo.png';
       color: c.$pure-white-color;
     }
     &:hover {
-      filter: drop-shadow(0px 4px 4px rgba(219, 52, 36, 0.1));
+      box-shadow: 0px 4px 4px rgba(219, 52, 36, 0.1);
       border-color: c.$accented-red-color;
     }
   }
@@ -85,10 +85,10 @@ $StbgImg: '@assets/images/donates/bgStrLogo.png';
     justify-content: center;
 
     &.ant-modal {
-      
+
 
       .ant-modal-close {
-        @include mut.sizedImportant(60px, 60px);       
+        @include mut.sizedImportant(60px, 60px);
         @include mut.circular(65px, c.$pure-white-color);
 
         .ant-modal-close-x svg{
@@ -103,7 +103,7 @@ $StbgImg: '@assets/images/donates/bgStrLogo.png';
         color: c.$pure-black-color;
         @include mut.with-font(ft.$closer-text-font, $font-size: 25px, $font-weight: 500);
       }
-    
+
       > h3 {
         @include mut.with-font(ft.$roboto-font, $font-size: 14px, $font-weight: 300);
       }
@@ -121,13 +121,13 @@ $StbgImg: '@assets/images/donates/bgStrLogo.png';
   .surveyModal {
     @include mut.sized(308px, 498px);
     &.ant-modal {
-      .ant-modal-content {      
+      .ant-modal-content {
         @include mut.bg-image($StbgImg, 35%, no-repeat);
       }
 
       .ant-modal-close {
         @include mut.positioned-as($position: absolute, $left: 92.36%, $top: -13px);
-        @include mut.sizedImportant(40px, 40px);       
+        @include mut.sizedImportant(40px, 40px);
         @include mut.circular(65px, c.$pure-white-color);
 
         .ant-modal-close-x svg{
@@ -135,14 +135,14 @@ $StbgImg: '@assets/images/donates/bgStrLogo.png';
         }
       }
     }
-  
+
   .surveyModalContent {
     padding-bottom: 0%;
     > h1 {
       color: c.$pure-black-color;
       @include mut.with-font(ft.$closer-text-font, $font-size: 20px, $font-weight: 500);
     }
-  
+
     > h3 {
       @include mut.with-font(ft.$roboto-font, $font-size: 14px, $font-weight: 300);
     }

--- a/src/assets/sass/variables/_variables.colors.scss
+++ b/src/assets/sass/variables/_variables.colors.scss
@@ -37,7 +37,7 @@ $base-arrow-filter-color: invert(97%) sepia(66%) saturate(423%)
   hue-rotate(212deg) brightness(113%) contrast(90%) !important;
 $selected-arrow-filter-color: invert(87%) sepia(0%) saturate(479%)
   hue-rotate(143deg) brightness(95%) contrast(81%) !important;
-$hovered-btn-filter-color: drop-shadow(0 2px 15px rgba(61, 0, 0, .25)) !important;
+$hovered-btn-box-shadow: 0 2px 15px rgba(61, 0, 0, .25) !important;
 
 $card-scrollbar-track-color: #DEDCDC !important;
 $modal-hover-color: #ECE9E9 !important;

--- a/src/features/AdditionalPages/ContactUsPage/ContactUs.styles.scss
+++ b/src/features/AdditionalPages/ContactUsPage/ContactUs.styles.scss
@@ -25,24 +25,24 @@
     .contactUsContent {
         text-align: center;
         @include mut.rem-margined(80px, 20px, 40px, 0px);
-     
-        
+
+
         > h1 {
         text-align: left;
           color: c.$pure-black-color;
           @include mut.with-font(ft.$closer-text-font, $font-size: 25px, $font-weight: 500);
         }
-      
+
         > h3 {
         text-align: left;
           @include mut.with-font(ft.$roboto-font, $font-size: 16px, $font-weight: 300);
         }
-      
-      
+
+
         .contactUsBtnContainer {
           @include mut.sized(180px, 46px);
           @include mut.full-rounded(10px);
-          
+
           margin-top: 10px;
           background-color: c.$accented-red-color;
           a {
@@ -52,7 +52,7 @@
             color: c.$pure-white-color;
           }
           &:hover {
-            filter: drop-shadow(0px 4px 4px rgba(219, 52, 36, 0.1));
+            box-shadow: 0px 4px 4px rgba(219, 52, 36, 0.1);(0px 4px 4px rgba(219, 52, 36, 0.1));
             border-color: c.$accented-red-color;
           }
         }
@@ -61,15 +61,15 @@
 
 @media screen and (max-width: 1024px) {
     .contactUsContainer{
-        padding: f.pxToRem(94px) f.pxToRem(10px) 0 f.pxToRem(10px);   
+        padding: f.pxToRem(94px) f.pxToRem(10px) 0 f.pxToRem(10px);
 
         .titleBlock{
-            margin-bottom: f.pxToRem(80px);    
+            margin-bottom: f.pxToRem(80px);
         }
         .contactUsContent {
             display: none;
         }
-    } 
+    }
 }
 
 @media screen and (max-width: 480px) {
@@ -80,6 +80,6 @@
         .contactUsContent {
             display: none;
         }
-    } 
+    }
 }
 

--- a/src/features/AdditionalPages/ContactUsPage/ContactUs.styles.scss
+++ b/src/features/AdditionalPages/ContactUsPage/ContactUs.styles.scss
@@ -52,7 +52,7 @@
             color: c.$pure-white-color;
           }
           &:hover {
-            box-shadow: 0px 4px 4px rgba(219, 52, 36, 0.1);(0px 4px 4px rgba(219, 52, 36, 0.1));
+            box-shadow: 0px 4px 4px rgba(219, 52, 36, 0.1);
             border-color: c.$accented-red-color;
           }
         }

--- a/src/features/AdditionalPages/ContactUsPage/MainBlock/ContactBlock/ContactBlock.styles.scss
+++ b/src/features/AdditionalPages/ContactUsPage/MainBlock/ContactBlock/ContactBlock.styles.scss
@@ -1,9 +1,11 @@
 @use "@sass/_utils.functions.scss" as f;
 @use "@sass/mixins/_utils.mixins.scss" as mut;
 @use "@assets/sass/variables/_variables.fonts.scss" as ft;
+@use "@sass/mixins/_vendor.mixins.scss" as vnd;
 
 @mixin hoverStyles {
-    box-shadow: 0 0 10px rgba(255, 0, 0, 0.612);
+    transform: translate3d(0, 0, 0); //required to make safari use gpu for render filter:drop-shadow
+    @include vnd.vendored(filter, 'drop-shadow(0 0 10px rgba(255, 0, 0, 0.612))');
     cursor: pointer;
 }
 

--- a/src/features/AdditionalPages/ContactUsPage/MainBlock/ContactBlock/ContactBlock.styles.scss
+++ b/src/features/AdditionalPages/ContactUsPage/MainBlock/ContactBlock/ContactBlock.styles.scss
@@ -3,7 +3,7 @@
 @use "@assets/sass/variables/_variables.fonts.scss" as ft;
 
 @mixin hoverStyles {
-    filter: drop-shadow(0 0 10px rgba(255, 0, 0, 0.612));
+    box-shadow: 0 0 10px rgba(255, 0, 0, 0.612);
     cursor: pointer;
 }
 
@@ -11,19 +11,19 @@
     .contactBlock{
         position: relative;
         bottom: f.pxToRem(50px);
-    
+
         .contactCover{
             position: relative;
-            z-index: 1;   
+            z-index: 1;
         }
-    
+
         .contactLogo{
             position: absolute;
             top: f.pxToRem(-110px);
             left: f.pxToRem(-54px);
             z-index: 0;
         }
-        
+
         .emailBlock img,  .phonesBlock img{
             margin-right: f.pxToRem(10px);
         }
@@ -35,7 +35,7 @@
                 @include hoverStyles;
             }
         }
-    
+
         .socials{
             .icon{
                 transition: all 0.2s ease;
@@ -45,12 +45,12 @@
                 @include hoverStyles;
             }
         }
-         
+
         .email{
             @include mut.with-font($font-family: ft.$closer-text-font, $font-weight: 500, $font-size: 36px);
             line-height: 48px;
             color: #1D1F23;
-        } 
+        }
     }
 }
 
@@ -60,22 +60,22 @@
             bottom: 0;
             .icon{
                 transform: scale(0.6);
-            } 
-    
+            }
+
             .contactLogo{
                 @include mut.with-font($font-family: ft.$closer-text-font, $font-weight: 500, $font-size: 54px);
                 line-height: 71px;
                 width: f.pxToRem(140px);
-                height: f.pxToRem(140px);    
-                
+                height: f.pxToRem(140px);
+
                 top: f.pxToRem(-18px);
                 left: f.pxToRem(220px);
             }
-    
-            .socials .icon{            
-                margin-right: f.pxToRem(20px);   
+
+            .socials .icon{
+                margin-right: f.pxToRem(20px);
             }
-    
+
             .email{
                 @include mut.with-font($font-family: ft.$closer-text-font, $font-weight: 500, $font-size: 20px);
                 line-height: 26px;
@@ -83,6 +83,6 @@
                 letter-spacing: 0.005em;
             }
         }
-    }   
-} 
+    }
+}
 

--- a/src/features/AdditionalPages/NewsPage/News.styles.scss
+++ b/src/features/AdditionalPages/NewsPage/News.styles.scss
@@ -252,7 +252,7 @@
                     border-radius: 10px;
                     width: 100%;
                     margin-bottom: 10px;
-                    filter: drop-shadow(0px 4px 4px rgba(219, 52, 36, 0.18));
+                    box-shadow: 0px 4px 4px rgba(219, 52, 36, 0.18);
                 }
             }
 

--- a/src/features/AdditionalPages/PartnersPage/ModalButtons/PartnersBtnCircle/PartnersBtnCircle.styles.scss
+++ b/src/features/AdditionalPages/PartnersPage/ModalButtons/PartnersBtnCircle/PartnersBtnCircle.styles.scss
@@ -19,9 +19,8 @@
     border: 3px solid c.$accented-red-color;
 
     &:hover {
-        @include vnd.vendored(filter, '#{c.$hovered-btn-filter-color}');
         color: c.$dark-red-color;
-        box-shadow: 0px 4px 4px rgba(219, 52, 36, 0.18);(0px 4px 4px rgba(219, 52, 36, 0.18));
+        box-shadow: 0px 4px 4px rgba(219, 52, 36, 0.18);
       }
   }
 
@@ -37,7 +36,7 @@
 
     .partnersBtnCircle{
       @include mut.circular(50px);
-      box-shadow: 0px 4px 4px rgba(219, 52, 36, 0.18);(0px 4px 4px rgba(219, 52, 36, 0.18));
+      box-shadow: 0px 4px 4px rgba(219, 52, 36, 0.18);
 
       svg{
         transform: scale(0.8);

--- a/src/features/AdditionalPages/PartnersPage/ModalButtons/PartnersBtnCircle/PartnersBtnCircle.styles.scss
+++ b/src/features/AdditionalPages/PartnersPage/ModalButtons/PartnersBtnCircle/PartnersBtnCircle.styles.scss
@@ -17,11 +17,11 @@
 
     cursor: pointer;
     border: 3px solid c.$accented-red-color;
-    
+
     &:hover {
         @include vnd.vendored(filter, '#{c.$hovered-btn-filter-color}');
         color: c.$dark-red-color;
-        filter: drop-shadow(0px 4px 4px rgba(219, 52, 36, 0.18));
+        box-shadow: 0px 4px 4px rgba(219, 52, 36, 0.18);(0px 4px 4px rgba(219, 52, 36, 0.18));
       }
   }
 
@@ -37,14 +37,14 @@
 
     .partnersBtnCircle{
       @include mut.circular(50px);
-      filter: drop-shadow(0px 4px 4px rgba(219, 52, 36, 0.18));
-      
+      box-shadow: 0px 4px 4px rgba(219, 52, 36, 0.18);(0px 4px 4px rgba(219, 52, 36, 0.18));
+
       svg{
         transform: scale(0.8);
       }
     }
     .partnersBtnText{
         display: none;
-    }    
+    }
   }
 }

--- a/src/features/AdditionalPages/SupportUsPage/components/DonationBlock.styles.scss
+++ b/src/features/AdditionalPages/SupportUsPage/components/DonationBlock.styles.scss
@@ -71,25 +71,25 @@
   .donatesBtnContainer {
     @include mut.flexed($gap: 10px, $wrap: wrap);
     margin: 0 20px;
-  
+
     > * {
       @include mut.sized(130px, 58px);
       @include mut.full-rounded(11px);
       @include mut.flex-centered();
-      
+
       border: 1px solid c.$dark-red-color;
       @include vnd.vendored(transition, 'background-color .75s ease');
-      filter: drop-shadow(0px 2px 4px rgba(0, 0, 0, 0.19));
+      box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.19);
       > span {
         @include vnd.vendored(transition, 'color .75s ease');
         @include mut.with-font(ft.$closer-text-font, $font-size: 20px, $font-weight: 500);
         color: c.$dark-red-color;
       }
-  
+
       &:where(:hover, &.active) {
         background-color: c.$accented-red-color;
         border: 3px solid c.$accented-red-color;
-  
+
         > span {
           color: c.$pure-white-color;
           font-weight: 500;
@@ -213,7 +213,7 @@
       @include mut.rem-margined($bottom: 20px);
       height: f.pxToRem(42px);
     }
-    
+
     .amountInput {
       @include mut.with-font(ft.$closer-text-font, $font-size: 32px, $font-weight: 500);
       display: flex;
@@ -260,7 +260,7 @@
       label {
         @include mut.sizedImportant($height: 25px);
       }
-      
+
       >.checkbox-borderline {
         display: flex;
         overflow: visible;

--- a/src/features/AdminPage/NewStreetcode/MapBlock/StatisticsStreetcodeAdmin/StatisticsAdmin.styles.scss
+++ b/src/features/AdminPage/NewStreetcode/MapBlock/StatisticsStreetcodeAdmin/StatisticsAdmin.styles.scss
@@ -12,7 +12,7 @@
   border: 3px solid #787878;
   box-shadow: 0px 7px 11px 2px rgba(0, 0, 0, 0.25);
   border-radius: 23px;
-  
+
   .input-id{
     @include mut.sized(300px, 40px);
     @include mut.full-rounded(10px);
@@ -26,10 +26,10 @@
     border: 3px solid #787878;
     border-radius: 23px;
     &:hover {
-      filter: drop-shadow(0px 4px 4px rgba(219, 52, 36, 0.1));
+      box-shadow: 0px 4px 4px rgba(219, 52, 36, 0.1);
       border-color: c.$accented-red-color;
     }
-    
+
   }
 
   .input-stnumber{
@@ -39,19 +39,19 @@
     border: 3px solid #787878;
     border-radius: 23px;
     &:hover {
-      filter: drop-shadow(0px 4px 4px rgba(219, 52, 36, 0.1));
+      box-shadow: 0px 4px 4px rgba(219, 52, 36, 0.1);(0px 4px 4px rgba(219, 52, 36, 0.1));
       border-color: c.$accented-red-color;
     }
-    
+
   }
   .red {
     border-color: red;
   }
-  
+
   .green {
     border-color: green;
   }
-  
+
   .notification {
     @include mut.with-font(ft.$roboto-font, 500, 13px, normal);
     line-height: 20px;
@@ -69,11 +69,11 @@
       color: c.$accented-red-color;
     }
     &:hover {
-      filter: drop-shadow(0px 4px 4px rgba(219, 52, 36, 0.1));
+      box-shadow: 0px 4px 4px rgba(219, 52, 36, 0.1);(0px 4px 4px rgba(219, 52, 36, 0.1));
       border-color: c.$accented-red-color;
     }
   }
-  
+
   h1{
     @include mut.with-font(ft.$roboto-font, 500, 22px, normal);
     line-height: 26px;
@@ -84,7 +84,7 @@
   .streetsBlock{
     @include mut.rem-padded($top:10px);
     width:100%;
-    
+
     p{
       @include mut.flexed($direction:row, $gap:5px);
       @include mut.with-font(ft.$roboto-font, 300, 20px, normal);
@@ -92,7 +92,7 @@
       color: c.$lighter-black-color;
       padding-left: f.pxToRem(20px);
     }
-    
+
     span{
       @include mut.with-font($font-weight:500, $font-size:22px);
       color: c.$accented-red-color;

--- a/src/features/AdminPage/NewStreetcode/MapBlock/StatisticsStreetcodeAdmin/StatisticsAdmin.styles.scss
+++ b/src/features/AdminPage/NewStreetcode/MapBlock/StatisticsStreetcodeAdmin/StatisticsAdmin.styles.scss
@@ -39,7 +39,7 @@
     border: 3px solid #787878;
     border-radius: 23px;
     &:hover {
-      box-shadow: 0px 4px 4px rgba(219, 52, 36, 0.1);(0px 4px 4px rgba(219, 52, 36, 0.1));
+      box-shadow: 0px 4px 4px rgba(219, 52, 36, 0.1);
       border-color: c.$accented-red-color;
     }
 
@@ -69,7 +69,7 @@
       color: c.$accented-red-color;
     }
     &:hover {
-      box-shadow: 0px 4px 4px rgba(219, 52, 36, 0.1);(0px 4px 4px rgba(219, 52, 36, 0.1));
+      box-shadow: 0px 4px 4px rgba(219, 52, 36, 0.1);
       border-color: c.$accented-red-color;
     }
   }

--- a/src/features/MainPage/StaticBanners/StaticBanner.styles.scss
+++ b/src/features/MainPage/StaticBanners/StaticBanner.styles.scss
@@ -7,7 +7,7 @@
 .mainPageBlockStaticBanner {
     @include mut.flexed($justify-content: space-between);
     @include mut.full-rounded(50px);
-    filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25));
+    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
     margin: f.pxToRem(50px) f.pxToRem(20px);
     padding: 0 f.pxToRem(46.5px);
     background-color: c.$pure-white-color;

--- a/src/features/StreetcodePage/DonateBtn/DonateBtn.styles.scss
+++ b/src/features/StreetcodePage/DonateBtn/DonateBtn.styles.scss
@@ -18,7 +18,7 @@
 
     &:hover {
       cursor: pointer;
-      @include vnd.vendored(filter, '#{c.$hovered-btn-filter-color}');
+      box-shadow: c.$hovered-btn-box-shadow;
       color: c.$dark-red-color;
     }
   }

--- a/src/features/StreetcodePage/MainBlock/StreetcodeCard/StreetcodeCard.styles.scss
+++ b/src/features/StreetcodePage/MainBlock/StreetcodeCard/StreetcodeCard.styles.scss
@@ -97,7 +97,7 @@
     position: relative;
     height: f.pxToRem(214px);
 
-    
+
 }
 
 .cardFooter {
@@ -153,7 +153,7 @@
     color: c.$accented-red-color;
   }
   &:hover {
-    filter: drop-shadow(0px 4px 4px rgba(219, 52, 36, 0.1));
+    box-shadow: 0px 4px 4px rgba(219, 52, 36, 0.1);
   }
 }
 .streetcodeImg {


### PR DESCRIPTION
## Summary of issue

Box shadows not working properly in Safari

## Summary of change
- change all filter:drop-shadow to box-shadow (where it's possible)
- add transform3d(0;0;0;) to all filter:drop-shadow that was left to display them right in Safari
- format styling with linter in files that was changed (side effect of opening files with linter)
-
## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
