### PR TITLE
- fix all sliders (slick && swiper) not showing all dots on overflow

### DIFF
--- a/src/app/layout/app/App.component.tsx
+++ b/src/app/layout/app/App.component.tsx
@@ -1,5 +1,6 @@
 import './App.styles.scss';
 import './ant-styles.overrides.scss';
+import './slick-slider.overrides.scss';
 
 import { observer } from 'mobx-react-lite';
 import ReactGA from 'react-ga4';

--- a/src/app/layout/app/slick-slider.overrides.scss
+++ b/src/app/layout/app/slick-slider.overrides.scss
@@ -1,0 +1,5 @@
+.slick-dots {
+    width: 100vw!important;
+    left: 50%!important;
+    transform: translate(-50%, 0)!important;
+}

--- a/src/features/MainPage/TeamSlider/TeamComponent.styles.scss
+++ b/src/features/MainPage/TeamSlider/TeamComponent.styles.scss
@@ -26,6 +26,7 @@ $bgImg: '@assets/images/streetcode-card/background.png';
 
     .mainContent {
         width: 100%;
+        margin-bottom: f.pxToRem(30px);
         @include mut.flex-centered();
         margin-top: f.pxToRem(1px);
         padding-top: f.pxToRem(1px);
@@ -98,7 +99,7 @@ $bgImg: '@assets/images/streetcode-card/background.png';
         padding-right: f.pxToRem(16px);
         padding-bottom: f.pxToRem(20px);
     }
-    
+
     .redirectButton {
         @include mut.sized($width: 95%, $height: 46px);
         @include mut.full-rounded(10px);

--- a/src/features/StreetcodePage/ArtGalleryBlock/ArtGalleryBlock.styles.scss
+++ b/src/features/StreetcodePage/ArtGalleryBlock/ArtGalleryBlock.styles.scss
@@ -12,8 +12,8 @@
     width: 100%;
 
     .slick-dots {
-        padding-right: pxToRem(16px);
-        margin-top: pxToRem(-60px);
+        padding: 0 pxToRem(16px);
+        bottom: pxToRem(-40px);
     }
 }
 

--- a/src/features/StreetcodePage/TimelineBlock/TimelineSwiper/TimelineSwiper.styles.scss
+++ b/src/features/StreetcodePage/TimelineBlock/TimelineSwiper/TimelineSwiper.styles.scss
@@ -30,7 +30,6 @@
       @include mut.sized(21px, 21px);
     }
   }
-  
 }
 
 .tickContainer {
@@ -89,9 +88,14 @@
   }
 
   .swiper-pagination {
-    @include mut.flexed();
+    @include mut.flexed(
+      $wrap: wrap,
+      $gap: 10px,
+      $justify-content: center
+    );
     position: absolute;
     top: f.pxToRem(350px);
+    padding: 0 f.pxToRem(20px);
   }
 
   .swiper-pagination-bullet {


### PR DESCRIPTION
- fix all sliders (slick && swiper) not showing all dots on overflow
- fix dots get under "побачити всю команду" button

Steps to reproduce:
- visit page of any streetcode person 
- screen smaller to make part of dots overflow screen

Actual behaviour: 
- not all dots are showing on a screen

Expected behaviour:
- dots just jump to another row, so all dots are available to click

<img width="468" alt="Screenshot 2023-08-28 at 8 01 57 PM" src="https://github.com/ita-social-projects/StreetCode_Client/assets/91199925/29c18334-4045-4413-88e5-1ff25574002b">
