### PR TITLE
Fixed wow-facts img description displaying

### DIFF
--- a/src/features/StreetcodePage/InterestingFactsBlock/InterestingFactItem/InterestingFactItem.component.tsx
+++ b/src/features/StreetcodePage/InterestingFactsBlock/InterestingFactItem/InterestingFactItem.component.tsx
@@ -4,21 +4,25 @@ import { observer } from 'mobx-react-lite';
 import { useEffect, useRef, useState } from 'react';
 import { Fact } from '@models/streetcode/text-contents.model';
 import { useModalContext } from '@stores/root-store';
-import useWindowSize from '@/app/common/hooks/stateful/useWindowSize.hook';
 
 import useIsVisible from '@/app/common/hooks/stateful/useIsVisible';
+import useWindowSize from '@/app/common/hooks/stateful/useWindowSize.hook';
 import base64ToUrl from '@/app/common/utils/base64ToUrl.utility';
 
 interface Props {
     fact: Fact;
     maxTextLength?: number;
     numberOfSlides: number;
+    index?: number;
+    middleFactIndex?: number;
 }
 
 const InterestingFactItem = ({
     fact: { factContent, title, id, image },
     maxTextLength = 250,
     numberOfSlides,
+    index,
+    middleFactIndex,
 }: Props) => {
     const windowSize = useWindowSize();
     const millisecondsToHideAfterOpening = 4000;
@@ -35,20 +39,22 @@ const InterestingFactItem = ({
         mainContent = `${factContent.substring(0, maxTextLength - 3)}...`;
     }
     useEffect(() => {
-        if (image?.imageDetails?.alt && isOnScreen) {
+        if (index === middleFactIndex && image?.imageDetails?.alt && isOnScreen) {
             setDescriptionVisible(true);
             timeout.current = setTimeout(() => {
                 setDescriptionVisible(false);
-                timeout.current = undefined;
             }, millisecondsToHideAfterOpening);
         }
-    }, [image, isOnScreen]);
+    }, [index, middleFactIndex, image, isOnScreen]);
 
     return (
-        <div className="interestingFactSlide" ref={elementRef}
-        onClick={(e) => {
-            {windowSize.width > 1024 && e.stopPropagation()}
-        }}>
+        <div
+            className="interestingFactSlide"
+            ref={elementRef}
+            onClick={(e) => {
+                { windowSize.width > 1024 && e.stopPropagation(); }
+            }}
+        >
             <div
                 className="slideImage"
             >
@@ -56,7 +62,7 @@ const InterestingFactItem = ({
                     src={base64ToUrl(image?.base64, image?.mimeType)}
                     alt=""
                 />
-                {image?.imageDetails?.alt ? (
+                {index === middleFactIndex && image?.imageDetails?.alt ? (
                     <div className={`description-popup ${descriptionVisible ? 'description-popup-visible' : ''}`}>
                         <p>{image?.imageDetails?.alt}</p>
                     </div>

--- a/src/features/StreetcodePage/InterestingFactsBlock/InterestingFacts.component.tsx
+++ b/src/features/StreetcodePage/InterestingFactsBlock/InterestingFacts.component.tsx
@@ -16,6 +16,8 @@ const InterestingFactsComponent = () => {
     const { factsStore } = useMobx();
     const { getStreetCodeId, errorStreetCodeId } = streetcodeStore;
     const [sliderArray, setSliderArray] = useState<Fact[]>([]);
+    const [middleFactIndex, setMiddleFactIndex] = useState(0);
+
     const facts = useRef<Fact[]>([]);
     useAsync(
         () => {
@@ -45,6 +47,12 @@ const InterestingFactsComponent = () => {
         infinite: sliderArray.length > 1,
         swipe: false,
         centerPadding: '-5px',
+        afterChange: (index: number) => {
+            const totalFacts = facts.current.length;
+            if (totalFacts > 1) {
+                setMiddleFactIndex((index) % totalFacts);
+            }
+        },
         responsive: [
             {
                 breakpoint: 480,
@@ -97,11 +105,13 @@ const InterestingFactsComponent = () => {
                                             className="heightContainer"
                                             {...setings}
                                         >
-                                            {sliderArray.map((fact) => (
+                                            {sliderArray.map((fact, index) => (
                                                 <InterestingFactItem
                                                     key={fact.id}
                                                     fact={fact}
                                                     numberOfSlides={sliderArray.length}
+                                                    index={index}
+                                                    middleFactIndex={middleFactIndex}
                                                 />
                                             ))}
                                         </BlockSlider>


### PR DESCRIPTION
dev
## **Description**
* The description of the image should be visible only for the central fact (when there are >= 3 of them)

## Code reviewers
- [ ] @ita-social-projects/lv-734-03-streetcode
- [ ] @ita-social-projects/lv-734-04-streetcode
- [ ] @ita-social-projects/lv-734-05-streetcode

## Summary of issue

ToDo

## Summary of change

ToDo

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
