### PR TITLE
Change loading sunshine icon in catalog 

### DIFF
--- a/src/app/stores/streetcodes-catalog-store.ts
+++ b/src/app/stores/streetcodes-catalog-store.ts
@@ -6,6 +6,8 @@ import { StreetcodeCatalogRecord } from '@/models/streetcode/streetcode-types.mo
 export default class StreetcodesCatalogStore {
     public catalog = new Array<StreetcodeCatalogRecord>();
 
+    public isNotEightorZero = false;
+
     constructor() {
         makeAutoObservable(this);
     }
@@ -13,14 +15,15 @@ export default class StreetcodesCatalogStore {
     public fetchCatalogStreetcodes = async (page: number, count = 8) => {
         try {
             const array = await StreetcodesApi.getAllCatalog(page, count);
-            console.log('Fetch_ARRAY:', array);
             if (
                 this.catalog.length === 0
                 || !array.some((item) => item.id === this.catalog.at(0)?.id)
             ) {
                 this.catalog = this.catalog.concat(array);
+                if (array.length !== 0 && array.length < count) {
+                    this.isNotEightorZero = true;
+                }
             }
-            console.log('CATALOG:', this.catalog);
         } catch (error) {}
     };
 

--- a/src/app/stores/streetcodes-catalog-store.ts
+++ b/src/app/stores/streetcodes-catalog-store.ts
@@ -13,10 +13,14 @@ export default class StreetcodesCatalogStore {
     public fetchCatalogStreetcodes = async (page: number, count = 8) => {
         try {
             const array = await StreetcodesApi.getAllCatalog(page, count);
-            if (this.catalog.length === 0
-                || !array.some((item) => item.id === this.catalog.at(0)?.id)) {
+            console.log('Fetch_ARRAY:', array);
+            if (
+                this.catalog.length === 0
+                || !array.some((item) => item.id === this.catalog.at(0)?.id)
+            ) {
                 this.catalog = this.catalog.concat(array);
             }
+            console.log('CATALOG:', this.catalog);
         } catch (error) {}
     };
 

--- a/src/features/StreetcodeCatalogPage/StreetcodeCatalog.component.tsx
+++ b/src/features/StreetcodeCatalogPage/StreetcodeCatalog.component.tsx
@@ -1,7 +1,7 @@
 import './StreetcodeCatalog.styles.scss';
 
 import { observer } from 'mobx-react-lite';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Footer from '@layout/footer/Footer.component';
 import useMobx from '@stores/root-store';
 
@@ -15,20 +15,29 @@ const StreetcodeCatalog = () => {
     const { fetchCatalogStreetcodes, getCatalogStreetcodesArray } = streetcodeCatalogStore;
     const [loading, setLoading] = useState(false);
     const [screen, setScreen] = useState(1);
+    const [noMoreStreetcodes, setNoMoreStreetcodes] = useState(false);
 
     const handleSetNextScreen = () => {
         setScreen(screen + 1);
     };
+    useEffect(() => {
+        if (screen > 1) {
+            setLoading(true);
+        }
+    }, [screen]);
 
     useAsync(async () => {
         const count = await StreetcodesApi.getCount();
         if (count === getCatalogStreetcodesArray.length) {
             return;
         }
-        setLoading(true);
+        //setLoading(true);
         setTimeout(() => {
-            Promise.all([fetchCatalogStreetcodes(screen, 8)]).then(() => {
+            Promise.all([fetchCatalogStreetcodes(screen, 8)]).then((result) => {
                 setLoading(false);
+                if (result[0].length < 8) {
+                    setNoMoreStreetcodes(true);
+                }
             });
         }, 1000);
     }, [screen]);
@@ -53,7 +62,7 @@ const StreetcodeCatalog = () => {
                 </div>
             </div>
             {
-                loading && (
+                loading && !noMoreStreetcodes && (
                     <div className="loadingWrapper">
                         <div id="loadingGif" />
                     </div>

--- a/src/features/StreetcodeCatalogPage/StreetcodeCatalog.component.tsx
+++ b/src/features/StreetcodeCatalogPage/StreetcodeCatalog.component.tsx
@@ -12,7 +12,7 @@ import StreetcodeCatalogItem from './StreetcodeCatalogItem/StreetcodeCatalogItem
 
 const StreetcodeCatalog = () => {
     const { streetcodeCatalogStore } = useMobx();
-    const { fetchCatalogStreetcodes, getCatalogStreetcodesArray} = streetcodeCatalogStore;
+    const { fetchCatalogStreetcodes, getCatalogStreetcodesArray, isNotEightorZero } = streetcodeCatalogStore;
     const [loading, setLoading] = useState(false);
     const [screen, setScreen] = useState(1);
 
@@ -30,12 +30,8 @@ const StreetcodeCatalog = () => {
         if (count === getCatalogStreetcodesArray.length) {
             return;
         }
-        setLoading(true);
         setTimeout(() => {
             Promise.all([fetchCatalogStreetcodes(screen, 8)]).then(() => {
-                if (getCatalogStreetcodesArray.length % 8 !== 0) { // Check if last fetch met the condition)
-                    setLoading(false); // Set loading to false
-                }
                 setLoading(false);
             });
         }, 1000);
@@ -61,7 +57,7 @@ const StreetcodeCatalog = () => {
                 </div>
             </div>
             {
-                loading && (
+                loading && !isNotEightorZero && (
                     <div className="loadingWrapper">
                         <div id="loadingGif" />
                     </div>

--- a/src/features/StreetcodeCatalogPage/StreetcodeCatalog.component.tsx
+++ b/src/features/StreetcodeCatalogPage/StreetcodeCatalog.component.tsx
@@ -12,10 +12,9 @@ import StreetcodeCatalogItem from './StreetcodeCatalogItem/StreetcodeCatalogItem
 
 const StreetcodeCatalog = () => {
     const { streetcodeCatalogStore } = useMobx();
-    const { fetchCatalogStreetcodes, getCatalogStreetcodesArray } = streetcodeCatalogStore;
+    const { fetchCatalogStreetcodes, getCatalogStreetcodesArray} = streetcodeCatalogStore;
     const [loading, setLoading] = useState(false);
     const [screen, setScreen] = useState(1);
-    const [noMoreStreetcodes, setNoMoreStreetcodes] = useState(false);
 
     const handleSetNextScreen = () => {
         setScreen(screen + 1);
@@ -31,13 +30,13 @@ const StreetcodeCatalog = () => {
         if (count === getCatalogStreetcodesArray.length) {
             return;
         }
-        //setLoading(true);
+        setLoading(true);
         setTimeout(() => {
-            Promise.all([fetchCatalogStreetcodes(screen, 8)]).then((result) => {
-                setLoading(false);
-                if (result[0].length < 8) {
-                    setNoMoreStreetcodes(true);
+            Promise.all([fetchCatalogStreetcodes(screen, 8)]).then(() => {
+                if (getCatalogStreetcodesArray.length % 8 !== 0) { // Check if last fetch met the condition)
+                    setLoading(false); // Set loading to false
                 }
+                setLoading(false);
             });
         }, 1000);
     }, [screen]);
@@ -62,7 +61,7 @@ const StreetcodeCatalog = () => {
                 </div>
             </div>
             {
-                loading && !noMoreStreetcodes && (
+                loading && (
                     <div className="loadingWrapper">
                         <div id="loadingGif" />
                     </div>


### PR DESCRIPTION
dev
## JIRA

* [Main JIRA ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## The animation "sunshine" (directory of streetcodes) should not appear during loading, but only when part of the streetcodes is displayed and the user flips further. Then the animation appears at the bottom (if the page does not have time to load everything quickly) - see. design in fig

ToDo

## The animation "sunshine" (directory of streetcodes) appears during loading, only when part of the streetcodes is displayed and the user flips further. Then the animation appears at the bottom if the page does not have time to load everything quickly)
issue [Change "sunshine" animation while loading in streetcode catalogs#745](https://github.com/ita-social-projects/StreetCode_Client/issues/745)
ToDo

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
