### PR TITLE
Image moved to right for wide screens and date added by Mariia Padalka

### DIFF
--- a/src/features/AdditionalPages/NewsPage/News.component.tsx
+++ b/src/features/AdditionalPages/NewsPage/News.component.tsx
@@ -1,25 +1,31 @@
+/* eslint-disable @typescript-eslint/no-non-null-asserted-optional-chain */
+/* eslint-disable max-len */
 import './News.styles.scss';
 
-import { useRouteUrl } from '@/app/common/hooks/stateful/useRouter.hook';
-import useMobx from '@/app/stores/root-store';
 import React, { useEffect, useRef, useState } from 'react';
-import { useAsync } from '@/app/common/hooks/stateful/useAsync.hook';
-import NewsApi from '@/app/api/news/news.api';
-import News from '@/models/news/news.model';
-import base64ToUrl from '@/app/common/utils/base64ToUrl.utility';
 import { Link } from 'react-router-dom';
-import BreadCrumbForNews from './BreadCrumbForNews/BreadCrumbForNews.component';
+import { NewsWithUrl } from '@models/news/news.model';
+import dayjs from 'dayjs';
 import parse from 'html-react-parser';
-import { NewsWithUrl, RandomNews } from '@models/news/news.model';
+
+import NewsApi from '@/app/api/news/news.api';
+import { useRouteUrl } from '@/app/common/hooks/stateful/useRouter.hook';
 import useWindowSize from '@/app/common/hooks/stateful/useWindowSize.hook';
-import { alsoReadArticleClickEvent, nextArticleClickEvent, prevArticleClickEvent } from '@/app/common/utils/googleAnalytics.unility';
+import base64ToUrl from '@/app/common/utils/base64ToUrl.utility';
+import { nextArticleClickEvent, prevArticleClickEvent } from '@/app/common/utils/googleAnalytics.unility';
+import useMobx from '@/app/stores/root-store';
+import News from '@/models/news/news.model';
+
+import BreadCrumbForNews from './BreadCrumbForNews/BreadCrumbForNews.component';
+import RandomNewsBlock from './RandomNewsBlock.component';
 
 const NewsPage = () => {
     const newsUrl = useRouteUrl();
     const [newsImg, setNewsImg] = useState<HTMLImageElement | null>(null);
     const [newsValue, setValue] = useState<NewsWithUrl>();
+    const [news, setNews] = useState<News>();
     const { imagesStore } = useMobx();
-    const [parsedNewsText, setParsedNewsText] = useState<string>("");
+    const [parsedNewsText, setParsedNewsText] = useState<string>('');
     const [paragraphsCount, setParCount] = useState<number>(0);
     const [width, setWidth] = useState(0);
     const windowSize = useWindowSize();
@@ -27,16 +33,19 @@ const NewsPage = () => {
     const [wrapperWidth, setWrapperWidth] = useState<number>(0);
     const { getImage, addImage } = imagesStore;
 
-    useEffect(
-        () => {
-            NewsApi.getNewsAndLinksByUrl(newsUrl)
-            .then(res => {
-                setValue(res)
+    useEffect(() => {
+        NewsApi.getNewsAndLinksByUrl(newsUrl)
+            .then((res) => {
+                setValue(res);
                 const value = res as NewsWithUrl;
-                setParsedNewsText(parse(value.news.text ?? "") as string);
+                setParsedNewsText(parse(value.news.text ?? '') as string);
                 setParCount(((value.news.text as string)?.match(/<p\b[^>]*>/gi) || []).length);
-            });            
-        }, [newsUrl]);
+            });
+        NewsApi.getByUrl(newsUrl)
+            .then((res) => {
+                setNews(res);
+            });
+    }, [newsUrl]);
 
     useEffect(
         () => {
@@ -44,119 +53,91 @@ const NewsPage = () => {
         },
         [newsValue?.news.url],
     );
-    
+
     useEffect(
         () => {
-            if(wrapperRef.current) {
-                setWrapperWidth(wrapperRef.current.offsetWidth)
+            if (wrapperRef.current) {
+                setWrapperWidth(wrapperRef.current.offsetWidth);
             }
         },
-        [windowSize]
-    )
+        [windowSize],
+    );
     useEffect(
         () => {
-            if(newsValue)
-            {
+            if (newsValue) {
                 if (newsValue.news.imageId != null) {
                     addImage(newsValue.news.image!);
-                    var newsimg = new Image;
+                    const newsimg = new Image();
                     if (newsValue.news.image) {
                         const imgUrl = base64ToUrl(getImage(newsValue.news.imageId!)?.base64, getImage(newsValue.news.imageId!)?.mimeType);
                         newsimg.src = imgUrl!;
                         newsimg.onload = function () {
                             setWidth(newsimg.width);
                             setNewsImg(newsimg);
-                        }
-                    }        
-                }
-                else {
+                        };
+                    }
+                } else {
                     setNewsImg(null);
                 }
             }
         },
         [newsValue?.news.imageId],
     );
-    
-    return (<div>
-        <div className="newsContainer">
-            <div className="wrapper" ref={wrapperRef}>
-                <BreadCrumbForNews separator={<div className="separator" />} news={newsValue?.news} />
-                <div className='NewsHeader'>
-                    <h1 className=''>{newsValue?.news.title}</h1>
-                </div>
-                <div className={`newsWithImageWrapper`}>
-                    {newsImg != null && (windowSize.width >= 1024) && (width < wrapperWidth * 0.6) ? (  
-                        <img
-                            className={"newsImage"}
-                            key={newsValue?.news.id}
-                            src={base64ToUrl(getImage(newsValue?.news.imageId!)?.base64, getImage(newsValue?.news.imageId!)?.mimeType)}
-                            alt={newsValue?.news.title}
-                        />
-                    ): ""}
-                    {newsImg != null && (windowSize.width < 1024) && (width < wrapperWidth * 0.6) ? (  
-                        <img
-                            className={"newsImage"}
-                            key={newsValue?.news.id}
-                            src={base64ToUrl(getImage(newsValue?.news.imageId!)?.base64, getImage(newsValue?.news.imageId!)?.mimeType)}
-                            alt={newsValue?.news.title}
-                        />
-                    ): ""}
-                    <div className="newsTextArea">
-                        {paragraphsCount >= 2 ? parsedNewsText.slice(0, 3) : parsedNewsText}
+
+    return (
+        <div>
+            <div className="newsContainer">
+                <div className="wrapper" ref={wrapperRef}>
+                    <BreadCrumbForNews separator={<div className="separator" />} news={newsValue?.news} />
+                    <div className="NewsHeader">
+                        <h1 className="">{newsValue?.news.title}</h1>
+                        <h3 className="news-date">{dayjs(news?.creationDate).format('DD.MM.YYYY')}</h3>
                     </div>
-                    {newsImg != null && (windowSize.width <= 1024) && (width >= wrapperWidth * 0.6) ? (  
-                        <img
-                            className={"newsGoodImageClass Full"}
-                            key={newsValue?.news.id}
-                            src={base64ToUrl(getImage(newsValue?.news.imageId!)?.base64, getImage(newsValue?.news.imageId!)?.mimeType)}
-                            alt={newsValue?.news.title}
-                        />
-                    ): ""}
-                    {newsImg != null && (windowSize.width > 1024) && (width >= wrapperWidth * 0.6) ? (  
-                        <img
-                            className={"newsGoodImageClass Full"}
-                            key={newsValue?.news.id}
-                            src={base64ToUrl(getImage(newsValue?.news.imageId!)?.base64, getImage(newsValue?.news.imageId!)?.mimeType)}
-                            alt={newsValue?.news.title}
-                        />
-                    ): ""}
-                    <div className="newsTextArea">
-                    {paragraphsCount >= 2 ? parsedNewsText.slice(3) : ""}
+                    <div className="newsWithImageWrapper">
+                        {newsImg != null && (windowSize.width > 1024) ? (
+                            <img
+                                className="newsImage"
+                                key={newsValue?.news.id}
+                                src={base64ToUrl(getImage(newsValue?.news.imageId!)?.base64, getImage(newsValue?.news.imageId!)?.mimeType)}
+                                alt={newsValue?.news.title}
+                            />
+                        ) : ''}
+                        <div className="newsTextArea">
+                            {paragraphsCount >= 2 ? parsedNewsText.slice(0, 3) : parsedNewsText}
+                        </div>
+                        {newsImg != null && (windowSize.width <= 1024) && (width >= wrapperWidth * 0.6) ? (
+                            <img
+                                className="newsGoodImageClass Full"
+                                key={newsValue?.news.id}
+                                src={base64ToUrl(getImage(newsValue?.news.imageId!)?.base64, getImage(newsValue?.news.imageId!)?.mimeType)}
+                                alt={newsValue?.news.title}
+                            />
+                        ) : ''}
+                        <div className="newsTextArea">
+                            {paragraphsCount >= 2 ? parsedNewsText.slice(3) : ''}
+                        </div>
                     </div>
-                </div>
-                <div className="newsLinks">
-                    <Link className={`Link ${newsValue?.prevNewsUrl === null ? 'toHide' : ''}`}
-                        to={`/news/${newsValue?.prevNewsUrl}`}
-                        onClick={prevArticleClickEvent}>
+                    <div className="newsLinks">
+                        <Link
+                            className={`Link ${newsValue?.prevNewsUrl === null ? 'toHide' : ''}`}
+                            to={`/news/${newsValue?.prevNewsUrl}`}
+                            onClick={prevArticleClickEvent}
+                        >
                         Попередня новина
-                    </Link>
-                    <Link className={`Link ${newsValue?.nextNewsUrl === null ? 'toHide' : ''}`}
-                        to={`/news/${newsValue?.nextNewsUrl}`}
-                        onClick={nextArticleClickEvent}>
+                        </Link>
+                        <Link
+                            className={`Link ${newsValue?.nextNewsUrl === null ? 'toHide' : ''}`}
+                            to={`/news/${newsValue?.nextNewsUrl}`}
+                            onClick={nextArticleClickEvent}
+                        >
                         Наступна новина
-                    </Link>
-                </div>
-                <div className={`randomNewsBlock ${newsValue?.news.url as unknown as string === newsValue?.randomNews.randomNewsUrl ? 'toHide' : ''}`}>
-                    <div className="randomNewsLink">
-                        <div className="additionalNewsText">
-                            Також читайте:
-                        </div>
-                        <div className="randomNewsTitleAndButtn">
-                            {newsValue?.randomNews.title}
-                            <div className="newsButtonContainer">
-                                <Link className={`Link ${newsValue?.news.url as unknown as string === newsValue?.randomNews.randomNewsUrl ? 'toHide' : ''}`} 
-                                to={`/news/${newsValue?.randomNews.randomNewsUrl}`} 
-                                onClick={alsoReadArticleClickEvent}>
-                                    <button>Перейти</button>
-                                </Link>
-                            </div>
-                        </div>
+                        </Link>
                     </div>
+                    <RandomNewsBlock newsValue={newsValue} />
                 </div>
             </div>
         </div>
-    </div>
     );
-}
+};
 
 export default NewsPage;

--- a/src/features/AdditionalPages/NewsPage/News.styles.scss
+++ b/src/features/AdditionalPages/NewsPage/News.styles.scss
@@ -21,6 +21,11 @@
             h1 {
                 @include mut.with-font($font-family: ft.$closer-text-font, $font-weight: 500, $font-size: 40px);
             }
+            .news-date {
+                @include mut.with-font($font-family: ft.$roboto-font, $font-weight: 300, $font-size: 15px);
+                color: c.$darkish-gray-color;
+                margin-top: f.pxToRem(8px);
+            }
         }
     }
 
@@ -53,8 +58,7 @@
             margin-left: f.pxToRem(20px);
             height: 100%;
             max-height: fit-content;
-            min-width: fit-content;
-            max-width: fit-content;
+            max-width: f.pxToRem(600px);
             float: right;
             border-radius: 24px;
         }

--- a/src/features/AdditionalPages/NewsPage/RandomNewsBlock.component.tsx
+++ b/src/features/AdditionalPages/NewsPage/RandomNewsBlock.component.tsx
@@ -1,0 +1,34 @@
+/* eslint-disable max-len */
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { NewsWithUrl } from '@models/news/news.model';
+
+import { alsoReadArticleClickEvent } from '@/app/common/utils/googleAnalytics.unility';
+
+interface RandomNewsBlockProps {
+  newsValue: NewsWithUrl | undefined;
+}
+
+const RandomNewsBlock: React.FC<RandomNewsBlockProps> = ({ newsValue }) => (
+    <div className={`randomNewsBlock ${newsValue?.news.url as unknown as string === newsValue?.randomNews.randomNewsUrl ? 'toHide' : ''}`}>
+        <div className="randomNewsLink">
+            <div className="additionalNewsText">
+        Також читайте:
+            </div>
+            <div className="randomNewsTitleAndButtn">
+                {newsValue?.randomNews.title}
+                <div className="newsButtonContainer">
+                    <Link
+                        className={`Link ${newsValue?.news.url as unknown as string === newsValue?.randomNews.randomNewsUrl ? 'toHide' : ''}`}
+                        to={`/news/${newsValue?.randomNews.randomNewsUrl}`}
+                        onClick={alsoReadArticleClickEvent}
+                    >
+                        <button type="button">Перейти</button>
+                    </Link>
+                </div>
+            </div>
+        </div>
+    </div>
+);
+
+export default RandomNewsBlock;


### PR DESCRIPTION
On the news page:
1) For MVP, we always make the picture on the right
2) Add the date under the heading
![image](https://github.com/ita-social-projects/StreetCode_Client/assets/61410143/6f7e9e6d-81bd-4613-9958-7fc9741caa2f)


Also fixed a lot of code and moved the component to another file