### PR TITLE
Incorrect aspect ratio at 1200 screen size

### DIFF
--- a/src/features/MainPage/TopCarousel/TopCarousel.styles.scss
+++ b/src/features/MainPage/TopCarousel/TopCarousel.styles.scss
@@ -19,7 +19,7 @@
 
   .carousel-image {
     width: 100%;
-    height: f.pxToRem(737px);
+    height: 100%;
   }
 
   .slick-dots li button {
@@ -63,7 +63,7 @@
 
   @media screen and (min-width: 1800px) {
     .carousel-image {
-      height: f.pxToRem(830px);
+      height: auto;
     }
   }
 }


### PR DESCRIPTION

## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

Issue #767 

## Summary of change

The aspect ratio of the banner image is changed in proportion to the change in screen width. - see. design in fig [[mocup.](https://www.figma.com/file/9ydz23Y1yKPGx92lsqBhak/StreetCode?node-id=4762%3A8707&mode=dev)]

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
