### PR TITLE
if name of team member is long, it should be displayed in 2 lines

### DIFF
--- a/src/features/AboutUsPage/TeamMemberCard/TeamMemberCard.styles.scss
+++ b/src/features/AboutUsPage/TeamMemberCard/TeamMemberCard.styles.scss
@@ -51,7 +51,7 @@
 
             h2 {
                 @include mut.with-font($font-family: ft.$closer-text-font, $font-weight: 500, $font-size: 23px);
-                @include mut.truncated($line-num: 1);
+                @include mut.truncated($line-num: 2);
             }
 
             p {


### PR DESCRIPTION
dev
## JIRA

* [Main JIRA ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

ToDo

## Summary of change

ToDo

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
