### PR TITLE
fix overflow in cards and lightbox mobile

### DIFF
--- a/src/app/common/components/modals/Lightbox/LightboxComponent.styles.scss
+++ b/src/app/common/components/modals/Lightbox/LightboxComponent.styles.scss
@@ -45,16 +45,7 @@
 
     @media screen and (min-width:1025px) {
 
-        .yarl__slide_description_container {
-            @include mut.sized($height: 159px);
-        }
-
-        .yarl__slide_title_container {
-            @include mut.sized($height: 68px);
-        }
-
         .yarl__slide_description {
-            @include mut.sized($height: 129px);
             @include mut.rem-margined($top: 5px, $left: 50px);
             @include mut.with-font($font-weight: 300);
             @include mut.with-font();
@@ -86,13 +77,8 @@
 
     @media screen and (max-width:1025px) {
         .yarl__slide_description_container {
-            @include mut.sized($height: 128px);
             background: rgba(0, 0, 0, 0.5);
             backdrop-filter: blur(26.5px);
-        }
-
-        .yarl__slide_title_container {
-            @include mut.sized($height: 45px);
         }
 
         .yarl__slide_description {

--- a/src/features/AdminPage/NewStreetcode/ArtGallery/components/ArtGallery/ArtGalleryAdminStyles.styles.scss
+++ b/src/features/AdminPage/NewStreetcode/ArtGallery/components/ArtGallery/ArtGalleryAdminStyles.styles.scss
@@ -107,16 +107,17 @@
     .imgTitle {
         @include mut.with-font();
         @include mut.rem-padded($bottom: 5px);
-        @include mut.truncated();
-        @include mut.with-font($font-size: 15px);
+        @include mut.truncated(2);
+        @include mut.with-font($font-size: 18px);
     }
 
     .imgDescription {
-        @include mut.with-font($font-size: 12px);
+        @include mut.with-font($font-size: 15px);
         @include mut.truncated();
     }
 
     .imgImg {
         border-radius: pxToRem(30px);
+        object-fit: cover;
     }
 }

--- a/src/features/StreetcodePage/ArtGalleryBlock/ArtGalleryItem/ArtGallerySlideItem.styles.scss
+++ b/src/features/StreetcodePage/ArtGalleryBlock/ArtGalleryItem/ArtGallerySlideItem.styles.scss
@@ -96,20 +96,21 @@
     }
 
     .imgData {
-        @include mut.sized(100%, 113px);
+        @include mut.sized(100%);
         @include mut.positioned-as($position: absolute, $bottom: 0);
         @include mut.colored($color: c.$pure-white-color, $bg-color: rgba(0, 0, 0, 0.5));
         visibility: hidden;
         opacity: 0;
         @include vnd.vendored(transition, 'all .5s ease');
-        @include mut.rounded($bottom-right: 30px, $bottom-left: 30px);
+        @include mut.rounded( $bottom-right: 30px, $bottom-left: 30px);
         padding: pxToRem(11px) pxToRem(21px);
     }
 
     .imgTitle {
         @include mut.with-font();
         @include mut.rem-padded($bottom: 5px);
-        @include mut.truncated();
+        @include mut.truncated(2);
+        @include mut.with-font($font-size: 18px);
     }
 
     .imgDescription {
@@ -119,8 +120,6 @@
 
     .imgImg {
         border-radius: pxToRem(30px);
-        height: 100%;
         object-fit: cover;
-        width:100%;
     }
 }


### PR DESCRIPTION
When hover on art gallery item (no matter big or small, no matter what screen) there should not be any text overflow. Also, when you open art to full screen you should see all text without '...'