### PR TITLE
fix news button overflowing

### DIFF
--- a/src/features/MainPage/NewsSlider/NewsSliderItem/NewsSliderItem.styles.scss
+++ b/src/features/MainPage/NewsSlider/NewsSliderItem/NewsSliderItem.styles.scss
@@ -145,8 +145,8 @@
             left: 0;
             right: 0;
 
-            height: f.pxToRem(54px);
-            padding-top: f.pxToRem(18px);
+            //height of 2 lines + 10px
+            height: f.pxToRem(46px);
             padding-left: f.pxToRem(30px);
 
             @include mut.with-font(ft.$roboto-font, $font-weight: bolder, $font-size: 15px);


### PR DESCRIPTION
<img width="861" alt="Screenshot 2023-11-10 at 1 21 59 PM" src="https://github.com/ita-social-projects/StreetCode_Client/assets/91199925/172514bd-6ac4-4821-ab64-10f5061050ed">
fix this overflow