### PR TITLE
fix not fetching streetcode on streetcode catalog page

### DIFF
--- a/src/features/StreetcodeCatalogPage/StreetcodeCatalogItem/StreetcodeCatalogItem.component.tsx
+++ b/src/features/StreetcodeCatalogPage/StreetcodeCatalogItem/StreetcodeCatalogItem.component.tsx
@@ -3,10 +3,8 @@ import './StreetcodeCatalogItem.styles.scss';
 
 import { observer } from 'mobx-react-lite';
 import { useEffect, useRef } from 'react';
-import { Link } from 'react-router-dom';
 import useMobx from '@stores/root-store';
 
-import useOnScreen from '@/app/common/hooks/scrolling/useOnScreen.hook';
 import useWindowSize from '@/app/common/hooks/stateful/useWindowSize.hook';
 import base64ToUrl from '@/app/common/utils/base64ToUrl.utility';
 import { toStreetcodeRedirectClickEvent } from '@/app/common/utils/googleAnalytics.unility';
@@ -22,9 +20,6 @@ const StreetcodeCatalogItem = ({ streetcode, isLast, handleNextScreen }: Props) 
     const { imagesStore: { getImage, fetchImage } } = useMobx();
     const elementRef = useRef<HTMLDivElement>(null);
     const classSelector = 'catalogItem';
-    const isOnScreen = useOnScreen(elementRef, classSelector);
-
-    useEffect(() => (isOnScreen && isLast ? () => handleNextScreen() : () => { }), [isOnScreen]);
 
     useEffect(() => {
         Promise.all([fetchImage(streetcode.imageId)]);
@@ -45,7 +40,38 @@ const StreetcodeCatalogItem = ({ streetcode, isLast, handleNextScreen }: Props) 
         e.preventDefault();
         handleClickRedirect();
     };
-    
+
+    useEffect(() => {
+        if (isLast) {
+            const loadOptions = {
+                root: null,
+                rootMargin: '0px',
+                threshold: 1.0,
+            };
+
+            const callback = (entries : any, intersectionObserver : any) => {
+                entries.forEach((entry : any) => {
+                    if (entry.isIntersecting) {
+                        handleNextScreen();
+                        intersectionObserver.unobserve(entry.target);
+                    }
+                });
+            };
+
+            const intersectionObserver = new IntersectionObserver(callback, loadOptions);
+
+            if (elementRef.current) {
+                intersectionObserver.observe(elementRef.current);
+            }
+
+            return () => {
+                if (elementRef.current) {
+                    intersectionObserver.unobserve(elementRef.current);
+                }
+            };
+        }
+    }, []);
+
     return (
         <>
             {windowsize.width > 1024 && (
@@ -55,7 +81,11 @@ const StreetcodeCatalogItem = ({ streetcode, isLast, handleNextScreen }: Props) 
                             <p>{streetcode.title}</p>
                             {
                                 streetcode.alias !== null && streetcode.alias?.trim() !== '' ? (
-                                    <p className="aliasText">({streetcode.alias})</p>
+                                    <p className="aliasText">
+(
+                                        {streetcode.alias}
+)
+                                    </p>
                                 ) : undefined
                             }
                         </div>
@@ -64,7 +94,7 @@ const StreetcodeCatalogItem = ({ streetcode, isLast, handleNextScreen }: Props) 
             )}
             {windowsize.width <= 1024 && (
                 <div>
-                    <a {...LinkProps} href={`/${streetcode.url}`} onTouchStart={() => toStreetcodeRedirectClickEvent(streetcode.url, 'catalog')}/>
+                    <a {...LinkProps} href={`/${streetcode.url}`} onTouchStart={() => toStreetcodeRedirectClickEvent(streetcode.url, 'catalog')} />
                     <div ref={elementRef} className="catalogItemText mobile">
                         <div className="heading" onClick={handleTextClick}>
                             <p>{streetcode.title}</p>

--- a/src/features/StreetcodeCatalogPage/StreetcodeCatalogItem/StreetcodeCatalogItem.component.tsx
+++ b/src/features/StreetcodeCatalogPage/StreetcodeCatalogItem/StreetcodeCatalogItem.component.tsx
@@ -46,7 +46,7 @@ const StreetcodeCatalogItem = ({ streetcode, isLast, handleNextScreen }: Props) 
             const loadOptions = {
                 root: null,
                 rootMargin: '0px',
-                threshold: 1.0,
+                thresholds: [0.75],
             };
 
             const callback = (entries : any, intersectionObserver : any) => {


### PR DESCRIPTION
dev
## Description
fix fetching streetcode on streetcode page, when resolution is too big or page is too scaled
Before:
![image](https://github.com/ita-social-projects/StreetCode_Client/assets/53005363/1a154267-cb89-45fb-88cd-d39b7cc2e594)
After:
![image](https://github.com/ita-social-projects/StreetCode_Client/assets/53005363/8509c1d8-7c13-44f3-9e41-6ca6b3cd5754)

## JIRA

* [Main JIRA ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

ToDo

## Summary of change

ToDo

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
