### PR TITLE
fix text overflow container on news and streetcode cards main page

### DIFF
--- a/src/features/MainPage/NewsSlider/NewsSliderItem/NewsSliderItem.styles.scss
+++ b/src/features/MainPage/NewsSlider/NewsSliderItem/NewsSliderItem.styles.scss
@@ -141,7 +141,7 @@
                     font-weight: 300;
 
                     @media (min-width: 360px) and (max-width: 767px) {
-                        @include mut.truncated(9);
+                        @include mut.truncated(8);
                     }
                 }
 

--- a/src/features/MainPage/StreetcodeSlider/StreetcodeSliderItem/StreetcodeSliderItem.styles.scss
+++ b/src/features/MainPage/StreetcodeSlider/StreetcodeSliderItem/StreetcodeSliderItem.styles.scss
@@ -126,6 +126,7 @@
 
         &SubTitle{
             font-weight: 500;
+            @include mut.truncated(1);
             @media screen and (max-width: 1024px) {
                text-align: center;
                 color: c.$lighter-black-color;


### PR DESCRIPTION
<img width="357" alt="Screenshot 2023-11-21 at 11 09 47 AM" src="https://github.com/ita-social-projects/StreetCode_Client/assets/91199925/812ce6c9-b6a3-4c28-b557-345c6c5ad781">

No overflow of main page on news as above

<img width="342" alt="Screenshot 2023-11-21 at 11 20 39 AM" src="https://github.com/ita-social-projects/StreetCode_Client/assets/91199925/720385b2-9e81-493c-8710-e8bf32d0792e">

One line title on mobile streetcode main page card as above