### PR TITLE
fix our partners title

### DIFF
--- a/src/features/MainPage/Heading/Heading.styles.scss
+++ b/src/features/MainPage/Heading/Heading.styles.scss
@@ -8,6 +8,7 @@
     @include mut.sized($height: 40px, $width: 100%);
     @include mut.rem-padded($left: 25px, $right: 20px);
     @include mut.flexed($justify-content: space-between, $align-items: center);
+    white-space: nowrap;
 
     .leftPart {
         @include mut.flexed($align-items: center);


### PR DESCRIPTION
dev
## Description
Our partners title takes only 1 row, instead of two(width<360px)
Before:
![1](https://github.com/ita-social-projects/StreetCode_Client/assets/53005363/1143ceb2-89da-46b0-8509-7dccdba8af3d)
Afrer:
![image](https://github.com/ita-social-projects/StreetCode_Client/assets/53005363/fa6dbb55-28af-4303-ac1a-93c3389086d7)

## JIRA

* [Main JIRA ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

ToDo

## Summary of change

ToDo

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
