### PR TITLE
handle click when streetcode url isn't loaded

### DIFF
--- a/src/features/MainPage/StreetcodeSlider/StreetcodeSliderItem/StreetcodeSliderItem.component.tsx
+++ b/src/features/MainPage/StreetcodeSlider/StreetcodeSliderItem/StreetcodeSliderItem.component.tsx
@@ -19,8 +19,10 @@ const StreetcodeSliderItem = ({ streetcode, image }: Props) => {
     });
 
     const handleClickRedirect = () => {
-        toStreetcodeRedirectClickEvent(streetcode.transliterationUrl, 'main_page');
-        window.location.href = streetcode.transliterationUrl;
+        if (streetcode.transliterationUrl) {
+            toStreetcodeRedirectClickEvent(streetcode.transliterationUrl, 'main_page');
+            window.location.href = streetcode.transliterationUrl;
+        }
     };
 
     const handleLinkClick = (e: React.MouseEvent<HTMLAnchorElement>) => {


### PR DESCRIPTION
As a user I want to click on streetcode slider card ( button "До стріткоду ") on main page and if it has no text on it I should not be redirected