### PR TITLE
Fix news image on safari

### DIFF
--- a/src/features/AdditionalPages/NewsPage/News.styles.scss
+++ b/src/features/AdditionalPages/NewsPage/News.styles.scss
@@ -36,7 +36,7 @@
             list-style-type: disc;
             padding-inline-start: revert;
           }
-          
+
           ol {
             list-style-type: decimal;
             padding-inline-start: revert;
@@ -66,8 +66,8 @@
         .newsImage {
             margin-bottom: f.pxToRem(20px);
             margin-left: f.pxToRem(20px);
-            height: 100%;
-            max-height: fit-content;
+            height: auto;
+            object-fit: contain;
             max-width: f.pxToRem(600px);
             float: right;
             border-radius: 24px;

--- a/src/features/AdditionalPages/NewsPage/News.styles.scss
+++ b/src/features/AdditionalPages/NewsPage/News.styles.scss
@@ -67,6 +67,7 @@
             margin-bottom: f.pxToRem(20px);
             margin-left: f.pxToRem(20px);
             height: auto;
+            max-height: 40rem;
             object-fit: contain;
             max-width: f.pxToRem(600px);
             float: right;


### PR DESCRIPTION
As a user, I want to see the news page in safari browser the same way I see it in Google Chrome