### PR TITLE
Fix code build for app deployment

### DIFF
--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -1,6 +1,5 @@
 const Dotenv = require('dotenv-webpack');
 const Webpack = require('webpack');
-const path = require('path');
 
 module.exports = {
     entry: {
@@ -22,7 +21,6 @@ module.exports = {
     },
     output: {
         filename: '[name].bundle.js',
-        path: path.resolve(__dirname, 'dist'),
         chunkFilename: '[name].chunk.js',
         publicPath: '/'
     },

--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -1,6 +1,5 @@
 const Dotenv = require('dotenv-webpack');
 const webpack = require("webpack");
-const path = require('path');
 
 module.exports = {
     entry: {
@@ -16,7 +15,6 @@ module.exports = {
     },
     output: {
         filename: '[name].bundle.js',
-        path: path.resolve(__dirname, 'dist'),
         chunkFilename: '[name].chunk.js',
         publicPath: '/',
         clean: true,


### PR DESCRIPTION
This PR aims to fix code build for app deployment

Main chages:
1) Revert resolved path for dist folder for dev and prod set ups

More detailed description:
Apparently one of the steps of code build is to check and form checksum of dist folder
`COPY --from=build /app/dist /usr/share/nginx/html`

But when codebuild does not find dist folder in certain place it thoughts an error
`ERROR: failed to calculate checksum of ref 54db9db1-1221-47af-b500-b94711656e2d::oegkooqz1emghikpa5t89zje6: "/app/dist": not found`

Why codebuild can not find dist folder?
Apperanty with this [PR](https://github.com/ita-social-projects/StreetCode_Client/pull/1041) there was a change that dist folder will be placed in diff location `[__dirname]/dist` (as official documentation [suggest](https://webpack.js.org/guides/code-splitting/#splitchunksplugin)) instead of just `/dist`

So by removing `path:` property we just restore original `/dist` folder placement.