### PR TITLE
Fixed indents in news page

### DIFF
--- a/src/app/common/components/Editor/QEditor.component.tsx
+++ b/src/app/common/components/Editor/QEditor.component.tsx
@@ -3,7 +3,7 @@ import './QEditor.styles.scss';
 
 import React, { useEffect, useRef, useState } from 'react';
 import ReactQuill, { UnprivilegedEditor } from 'react-quill';
-import removeHtmlTags from '@app/common/utils/removeHtmlTags.utility';
+import { indentsBetweenParagraphsHtml, removeHtmlTags } from '@app/common/utils/removeHtmlTags.utility';
 import { Sources } from 'quill';
 
 import 'react-quill/dist/quill.snow.css';
@@ -22,7 +22,8 @@ interface EditorProps {
 const Editor: React.FC<EditorProps> = ({
     qRef, value, onChange, maxChars, initialVal, selectionChange,
 }) => {
-    const [val, setVal] = useState(value);
+    const indentedValue = indentsBetweenParagraphsHtml(value);
+    const [val, setVal] = useState(indentedValue);
     const [rawText, setRawText] = useState(removeHtmlTags(value) ?? '');
     const [characterCount, setCharacterCount] = useState(rawText.length ?? 0);
     const [validateDescription, setValidateDescription] = useState<boolean>(false);
@@ -37,6 +38,10 @@ const Editor: React.FC<EditorProps> = ({
     };
 
     useEffect(() => {
+        if (value.includes('\n')) {
+            const preservedIndents = indentsBetweenParagraphsHtml(value);
+            setVal(preservedIndents);
+        }
         const valueWithoutHtml = removeHtmlTags(value);
         setRawText(valueWithoutHtml);
     }, [value]);

--- a/src/app/common/components/Editor/QEditor.component.tsx
+++ b/src/app/common/components/Editor/QEditor.component.tsx
@@ -3,7 +3,7 @@ import './QEditor.styles.scss';
 
 import React, { useEffect, useRef, useState } from 'react';
 import ReactQuill, { UnprivilegedEditor } from 'react-quill';
-import { indentsBetweenParagraphsHtml, removeHtmlTags } from '@app/common/utils/removeHtmlTags.utility';
+import { refactorIndentsHtml, removeHtmlTags } from '@app/common/utils/removeHtmlTags.utility';
 import { Sources } from 'quill';
 
 import 'react-quill/dist/quill.snow.css';
@@ -22,7 +22,7 @@ interface EditorProps {
 const Editor: React.FC<EditorProps> = ({
     qRef, value, onChange, maxChars, initialVal, selectionChange,
 }) => {
-    const indentedValue = indentsBetweenParagraphsHtml(value);
+    const indentedValue = refactorIndentsHtml(value);
     const [val, setVal] = useState(indentedValue);
     const [rawText, setRawText] = useState(removeHtmlTags(value) ?? '');
     const [characterCount, setCharacterCount] = useState(rawText.length ?? 0);
@@ -39,7 +39,7 @@ const Editor: React.FC<EditorProps> = ({
 
     useEffect(() => {
         if (value.includes('\n')) {
-            const preservedIndents = indentsBetweenParagraphsHtml(value);
+            const preservedIndents = refactorIndentsHtml(value);
             setVal(preservedIndents);
         }
         const valueWithoutHtml = removeHtmlTags(value);

--- a/src/app/common/components/modals/Sources/SourcesModal.styles.scss
+++ b/src/app/common/components/modals/Sources/SourcesModal.styles.scss
@@ -59,10 +59,10 @@ $CancelBtn: "/src/assets/images/utils/Cancel_btn.svg";
 
   .mainContentContainer {
     height: pxToRem(570px);
-    @include mut.flexed($direction: column, $gap: 10px);
     @include mut.rem-margined(30px, 10px, 30px, 30px);
     padding-right: pxToRem(10px);
     overflow-y: scroll;
+    white-space: pre-line;
     font-weight: 300;
     font-size: 15px;
 

--- a/src/app/common/utils/removeHtmlTags.utility.ts
+++ b/src/app/common/utils/removeHtmlTags.utility.ts
@@ -3,4 +3,4 @@ export const removeHtmlTags = (content: string) => content.replace(/<[^>]*>|&nbs
     return '';
 });
 
-export const indentsBetweenParagraphsHtml = (content: string) => content.replace(/\n/g, '<p><br></p>');
+export const refactorIndentsHtml = (content: string) => content.replace(/\n/g, '<p><br></p>');

--- a/src/app/common/utils/removeHtmlTags.utility.ts
+++ b/src/app/common/utils/removeHtmlTags.utility.ts
@@ -1,6 +1,6 @@
-const removeHtmlTags = (content: string) => content.replace(/<[^>]*>|&nbsp;/g, (match) => {
+export const removeHtmlTags = (content: string) => content.replace(/<[^>]*>|&nbsp;/g, (match) => {
     if (match === '&nbsp;') return ' ';
     return '';
 });
 
-export default removeHtmlTags;
+export const indentsBetweenParagraphsHtml = (content: string) => content.replace(/\n/g, '<p><br></p>');

--- a/src/features/AdditionalPages/NewsPage/News.styles.scss
+++ b/src/features/AdditionalPages/NewsPage/News.styles.scss
@@ -47,8 +47,6 @@
             overflow-wrap: break-word;
 
             p {
-                padding-bottom: f.pxToRem(24px);
-
                 strong {
                     @include mut.with-font($font-family: ft.$closer-text-font, $font-weight: 500);
                 }
@@ -79,6 +77,7 @@
         @include mut.with-font($font-family: ft.$roboto-font, $font-weight: 500, $font-size: 20px);
         @include mut.flexed($justify-content: space-between, $align-items: center);
         line-height: f.pxToRem(14px);
+        padding-top: f.pxToRem(24px);
         text-align: center;
         text-decoration: underline;
         text-decoration-color: c.$dark-red-color;

--- a/src/features/AdditionalPages/NewsPage/News.styles.scss
+++ b/src/features/AdditionalPages/NewsPage/News.styles.scss
@@ -45,6 +45,7 @@
         .newsTextArea {
             @include mut.with-font($font-family: ft.$roboto-font, $font-weight: 300, $font-size: 20px);
             overflow-wrap: break-word;
+            white-space: pre-line;
 
             p {
                 strong {
@@ -154,6 +155,7 @@
         }
 
         .newsTextArea {
+            white-space: pre-line;
             @include mut.with-font($font-family: ft.$roboto-font, $font-weight: 300, $font-size: 20px);
         }
 
@@ -198,6 +200,7 @@
         }
 
         .newsTextArea {
+            white-space: pre-line;
             @include mut.with-font($font-family: ft.$roboto-font, $font-weight: 300, $font-size: 16px);
         }
 

--- a/src/features/AdminPage/JobsPage/JobsModal/JobsModal.component.tsx
+++ b/src/features/AdminPage/JobsPage/JobsModal/JobsModal.component.tsx
@@ -47,8 +47,8 @@ const JobsModal = ({ open, setOpen, currentId }: Props) => {
             if (open && currentId !== 0) {
                 try {
                     const currentJob = await JobApi.getById(currentId);
-                    setCurrent(currentJob);
                     setQuillEditorContent(textEditor.current, currentJob?.description);
+                    setCurrent(currentJob);
                     form.setFieldsValue({
                         title: currentJob?.title,
                         status: currentJob?.status ? 'setActive' : 'setInactive',

--- a/src/features/AdminPage/NewStreetcode/ForFansBlock/ForFansAdminModal/ForFansAdminModal.component.tsx
+++ b/src/features/AdminPage/NewStreetcode/ForFansBlock/ForFansAdminModal/ForFansAdminModal.component.tsx
@@ -97,6 +97,7 @@ const ForFansModal = ({
         setTextIsPresent(false);
         setTextIsChanged(false);
         setOpen(false);
+        editorRef.current?.editor?.setText('');
     };
 
     async function fetchData() {
@@ -108,8 +109,8 @@ const ForFansModal = ({
         categoryUpdate.current = sourceCreateUpdateStreetcode.ElementToUpdate;
         const categoryText = categoryUpdate?.current?.text;
         if (categoryUpdate.current && open) {
-            setEditorContent(categoryText ?? '');
             setQuillEditorContent(editorRef.current, categoryText ?? '');
+            setEditorContent(categoryText ?? '');
             form.setFieldValue('category', categoryUpdate.current.sourceLinkCategoryId);
         } else {
             categoryUpdate.current = null;
@@ -141,7 +142,6 @@ const ForFansModal = ({
         isEditedCategoryPersisted: boolean,
     ) => {
         if (!isEditedCategoryPersisted) {
-            console.log(editorContent);
             sourceCreateUpdateStreetcode
                 .addSourceCategoryContent({
                     id: getNewMinNegativeId(sourceCreateUpdateStreetcode.streetcodeCategoryContents.map((x) => x.id)),

--- a/src/features/AdminPage/NewsPage/NewsModal/NewsModal.component.tsx
+++ b/src/features/AdminPage/NewsPage/NewsModal/NewsModal.component.tsx
@@ -113,8 +113,8 @@ const NewsModal: React.FC<{
                     },
                 ] : [],
             });
-
             setQuillEditorContent(editorRef.current, newsItem.text);
+            setData(newsItem.text);
         } else {
             imageId.current = 0;
             image.current = undefined;


### PR DESCRIPTION
dev
## NOTE for devs
**1. It's OK that you cannot save streetcode in this PR!**
**2. The bug with too big indentations in for fans modal window will be fixed as soon as higher priority tasks are completed**


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

ToDo

## Summary of change

ToDo

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
