### PR TITLE
refactor StreetcodeSliderItem and NewsSliderItem to use Link for redirects

### DIFF
--- a/src/app/common/components/CardText/CardText.component.tsx
+++ b/src/app/common/components/CardText/CardText.component.tsx
@@ -1,19 +1,19 @@
 import './CardText.styles.scss';
 
-import { useEffect, useMemo } from 'react';
-import { useMediaQuery } from 'react-responsive';
+import { Link } from 'react-router-dom';
 
 type Props = {
     moreBtnText?: string,
+    moreBtnAsLink?: { link: string, state: any },
     className?: string,
-    onBtnClick: any,
+    onBtnClick?: (event: any) => void,
     title: string
     subTitle?: string,
     text: string
 };
 
 const CardText = ({
-    moreBtnText = 'Трохи ще...', title, text, subTitle, className, onBtnClick,
+    moreBtnText = 'Трохи ще...', title, text, subTitle, className, onBtnClick, moreBtnAsLink,
 }:Props) => (
     <div className={`cardTextContainer ${className}`}>
         <div className="cardTextContainerTopPart">
@@ -21,12 +21,25 @@ const CardText = ({
             {subTitle ? <p className="cardTextContainerSubTitle">{subTitle}</p> : <></>}
             <p className="cardTextContainerText">{text}</p>
         </div>
-        <p
-            className="cardTextContainerButton"
-            onClick={onBtnClick}
-        >
-            {moreBtnText}
-        </p>
+        {moreBtnAsLink
+            ? (
+                <Link
+                    to={moreBtnAsLink.link}
+                    state={moreBtnAsLink.state}
+                    className="cardTextContainerButton"
+                >
+                    {moreBtnText}
+                </Link>
+            )
+            : (
+                <p
+                    className="cardTextContainerButton"
+                    onClick={onBtnClick}
+                >
+                    {moreBtnText}
+                </p>
+            )}
+
     </div>
 );
 

--- a/src/app/common/utils/window.utility.tsx
+++ b/src/app/common/utils/window.utility.tsx
@@ -7,4 +7,7 @@ const scrollWithOffset = (el: any, offset: number) => {
     });
 };
 
+const clearWindowHistoryState = () => window.history.replaceState({}, document.title, window.location.pathname);
+
 export default scrollWithOffset;
+export { clearWindowHistoryState };

--- a/src/features/AdditionalPages/NewsPage/News.component.tsx
+++ b/src/features/AdditionalPages/NewsPage/News.component.tsx
@@ -4,10 +4,9 @@
 import './News.styles.scss';
 
 import React, { useEffect, useRef, useState } from 'react';
-import {
-    Link, NavigationType, useLocation, useNavigate, useNavigationType,
-} from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { NewsWithUrl } from '@models/news/news.model';
+import { clearWindowHistoryState } from '@utils/window.utility';
 import dayjs from 'dayjs';
 import parse from 'html-react-parser';
 
@@ -17,9 +16,12 @@ import useScrollToTop from '@/app/common/hooks/scrolling/useScrollToTop.hook';
 import { useRouteUrl } from '@/app/common/hooks/stateful/useRouter.hook';
 import useWindowSize from '@/app/common/hooks/stateful/useWindowSize.hook';
 import base64ToUrl from '@/app/common/utils/base64ToUrl.utility';
-import { nextArticleClickEvent, prevArticleClickEvent } from '@/app/common/utils/googleAnalytics.unility';
+import {
+    nextArticleClickEvent,
+    prevArticleClickEvent, toArticleRedirectClickEvent,
+} from '@/app/common/utils/googleAnalytics.unility';
+// eslint-disable-next-line import/extensions
 import useMobx from '@/app/stores/root-store';
-import News from '@/models/news/news.model';
 
 import BreadCrumbForNews from './BreadCrumbForNews/BreadCrumbForNews.component';
 import RandomNewsBlock from './RandomNewsBlock.component';
@@ -27,6 +29,7 @@ import RandomNewsBlock from './RandomNewsBlock.component';
 const NewsPage = () => {
     const newsUrl = useRouteUrl();
     const navigate = useNavigate();
+    const location = useLocation();
     const [newsImg, setNewsImg] = useState<HTMLImageElement | null>(null);
     const [newsValue, setValue] = useState<NewsWithUrl>();
     const { imagesStore } = useMobx();
@@ -37,6 +40,15 @@ const NewsPage = () => {
     const wrapperRef = useRef<HTMLDivElement>(null);
     const [wrapperWidth, setWrapperWidth] = useState<number>(0);
     const { getImage, addImage } = imagesStore;
+
+    useEffect(() => {
+        const fromPage = location.state?.fromPage;
+
+        if (fromPage) {
+            toArticleRedirectClickEvent(newsUrl, fromPage);
+            clearWindowHistoryState();
+        }
+    }, []);
 
     useEffect(() => {
         NewsApi.getNewsAndLinksByUrl(newsUrl)

--- a/src/features/MainPage/NewsSlider/NewsSliderItem/NewsSliderItem.component.tsx
+++ b/src/features/MainPage/NewsSlider/NewsSliderItem/NewsSliderItem.component.tsx
@@ -1,12 +1,12 @@
 import './NewsSliderItem.styles.scss';
 
 import { useMediaQuery } from 'react-responsive';
+import { useNavigate } from 'react-router-dom';
 import CardText from '@components/CardText/CardText.component';
 import dayjs from 'dayjs';
 import htmlReactParser from 'html-react-parser';
 
 import base64ToUrl from '@/app/common/utils/base64ToUrl.utility';
-import { toArticleRedirectClickEvent } from '@/app/common/utils/googleAnalytics.unility';
 import Image from '@/models/media/image.model';
 import News from '@/models/news/news.model';
 
@@ -20,14 +20,9 @@ const NewsSliderItem = ({ news, image }: Props) => {
         query: '(max-width: 1024px)',
     });
 
-    const handleClickRedirect = () => {
-        toArticleRedirectClickEvent(news.url.toString(), 'main_page');
-        window.location.href = `news/${news.url.toString()}`;
-    };
-    const handleLinkClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
-        e.preventDefault();
-        handleClickRedirect();
-    };
+    const navigate = useNavigate();
+    const historyState = { fromPage: 'main_page' };
+    const handleClickRedirect = () => navigate(news.url.toString(), { state: historyState });
 
     const tempElement = document.createElement('div');
     tempElement.innerHTML = news?.text;
@@ -35,7 +30,7 @@ const NewsSliderItem = ({ news, image }: Props) => {
     const strongElements = tempElement.querySelectorAll('strong');
 
     strongElements.forEach((strongElement) => {
-        const parent = strongElement.parentNode;
+        const parent = strongElement.parentNode as ParentNode;
         while (strongElement.firstChild) {
             parent.insertBefore(strongElement.firstChild, strongElement);
         }
@@ -52,16 +47,17 @@ const NewsSliderItem = ({ news, image }: Props) => {
                         key={image?.id}
                         src={base64ToUrl(image?.base64, image?.mimeType)}
                         className="newsPageImg"
+                        alt="news"
                     />
                 </div>
                 <div className="newsSlideText">
                     <div className="newsContainer">
                         <div className="subContainer">
                             <CardText
-                                onBtnClick={handleLinkClick}
+                                moreBtnAsLink={{ link: news.url.toString(), state: historyState }}
                                 moreBtnText="До новини"
                                 title={news?.title}
-                                text={htmlReactParser(cleanText?.substring(0, 800))}
+                                text={htmlReactParser(cleanText?.substring(0, 800)) as string}
                                 subTitle={dayjs(news.creationDate).format('DD.MM.YYYY') ?? ''}
                             />
                         </div>

--- a/src/features/MainPage/StreetcodeSlider/StreetcodeSliderItem/StreetcodeSliderItem.component.tsx
+++ b/src/features/MainPage/StreetcodeSlider/StreetcodeSliderItem/StreetcodeSliderItem.component.tsx
@@ -1,10 +1,10 @@
 import './StreetcodeSliderItem.styles.scss';
 
 import { useMediaQuery } from 'react-responsive';
+import { useNavigate } from 'react-router-dom';
 import CardText from '@components/CardText/CardText.component';
 
 import base64ToUrl from '@/app/common/utils/base64ToUrl.utility';
-import { toStreetcodeRedirectClickEvent } from '@/app/common/utils/googleAnalytics.unility';
 import Image from '@/models/media/image.model';
 import { StreetcodeMainPage } from '@/models/streetcode/streetcode-types.model';
 
@@ -18,21 +18,17 @@ const StreetcodeSliderItem = ({ streetcode, image }: Props) => {
         query: '(max-width: 480px)',
     });
 
+    const navigate = useNavigate();
+    const historyState = { fromPage: 'main_page' };
     const handleClickRedirect = () => {
         if (streetcode.transliterationUrl) {
-            toStreetcodeRedirectClickEvent(streetcode.transliterationUrl, 'main_page');
-            window.location.href = streetcode.transliterationUrl;
+            navigate(streetcode.transliterationUrl, { state: historyState });
         }
-    };
-
-    const handleLinkClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
-        e.preventDefault();
-        handleClickRedirect();
     };
 
     return (
         <div className="mainPageStreetCodeSlider">
-            <div className="itemStreetCodeMainPage" onClick={isMobile ? handleLinkClick : undefined}>
+            <div className="itemStreetCodeMainPage" onClick={isMobile ? handleClickRedirect : undefined}>
                 <div className="leftSlider">
                     <div className={`leftSliderContent ${image?.id ? '' : 'skeleton'}`}>
                         {image?.id
@@ -52,7 +48,7 @@ const StreetcodeSliderItem = ({ streetcode, image }: Props) => {
                         text={streetcode.teaser}
                         subTitle={streetcode.text}
                         moreBtnText="До стріткоду"
-                        onBtnClick={handleLinkClick}
+                        moreBtnAsLink={{ link: streetcode.transliterationUrl, state: historyState }}
                     />
                 </div>
             </div>

--- a/src/features/StreetcodePage/Streetcode.component.tsx
+++ b/src/features/StreetcodePage/Streetcode.component.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable global-require */
 import './Streetcode.styles.scss';
 
 import { observer } from 'mobx-react-lite';
@@ -13,6 +14,8 @@ import QRBlock from '@streetcode/QRBlock/QR.component';
 import SourcesBlock from '@streetcode/SourcesBlock/Sources.component';
 import TextBlockComponent from '@streetcode/TextBlock/TextBlock.component';
 import TickerBlock from '@streetcode/TickerBlock/Ticker.component';
+import { toStreetcodeRedirectClickEvent } from '@utils/googleAnalytics.unility';
+import { clearWindowHistoryState } from '@utils/window.utility';
 
 import StatisticRecordApi from '@/app/api/analytics/statistic-record.api';
 import StreetcodesApi from '@/app/api/streetcode/streetcodes.api';
@@ -24,7 +27,6 @@ import Streetcode from '@/models/streetcode/streetcode-types.model';
 
 import ArtGalleryBlockComponent from './ArtGalleryBlock/ArtGalleryBlock.component';
 import InterestingFactsComponent from './InterestingFactsBlock/InterestingFacts.component';
-import MapBlock from './MapBlock/MapBlock.component';
 import PartnersComponent from './PartnersBlock/Partners.component';
 import RelatedFiguresComponent from './RelatedFiguresBlock/RelatedFigures.component';
 import TimelineBlockComponent from './TimelineBlock/TimelineBlock.component';
@@ -40,8 +42,8 @@ const StreetcodeContent = () => {
     const [streetcode, setStreecode] = useState<Streetcode>();
 
     const navigate = useNavigate();
-    const [searchParams, setSearchParams] = useSearchParams();
     const location = useLocation();
+    const [searchParams, setSearchParams] = useSearchParams();
     const isMobile = useMediaQuery({
         query: '(max-width: 4800px)',
     });
@@ -87,6 +89,13 @@ const StreetcodeContent = () => {
 
     useEffect(() => {
         setCurrentStreetcodeId(streetcodeUrl.current).then((val) => setStreecode(val));
+
+        const fromPage = location.state?.fromPage;
+
+        if (fromPage) {
+            toStreetcodeRedirectClickEvent(streetcodeUrl.current, fromPage);
+            clearWindowHistoryState();
+        }
     }, []);
 
     return (
@@ -116,7 +125,11 @@ const StreetcodeContent = () => {
                 ) : (
                     <></>
                 )}
-                <RelatedFiguresComponent streetcode={streetcode} setActiveTagId={setActiveTagId} setShowAllTags={setShowAllTags} />
+                <RelatedFiguresComponent
+                    streetcode={streetcode}
+                    setActiveTagId={setActiveTagId}
+                    setShowAllTags={setShowAllTags}
+                />
                 <SourcesBlock />
             </ProgressBar>
             <QRBlock />


### PR DESCRIPTION
Open streetcode and news from main page to test new redirect.

+ You should be able to right-click on the link and open it in a new tab

Also please check visuals on `StreetcodeSliderItem` (main page), `NewsSliderItem` (main page), `InterestingFactItem` (streetcode page), `VacancyComponent` (about us page) for **visual similarity** to prod or stage. 