### PR TITLE
Links open in new tabs

### DIFF
--- a/src/features/AboutUsPage/Vacancies/Vacancy/VacancyModal/VacancyModal.component.tsx
+++ b/src/features/AboutUsPage/Vacancies/Vacancy/VacancyModal/VacancyModal.component.tsx
@@ -60,7 +60,7 @@ const VacancyModal = ({ isOpen, setOpen, job }: Props) => {
                     <Button
                         className="vacancyModalButton streetcode-custom-button"
                         onClick={(e) => {
-                            window.location.href = EMAIL_INFO.WRITE_EMAIL_TO_US;
+                            window.open(EMAIL_INFO.WRITE_EMAIL_TO_US, '_blank');
                             e.preventDefault();
                         }}
                     >

--- a/src/features/AboutUsPage/Vacancies/Vacancy/VacancyModal/VacancyModal.component.tsx
+++ b/src/features/AboutUsPage/Vacancies/Vacancy/VacancyModal/VacancyModal.component.tsx
@@ -59,9 +59,8 @@ const VacancyModal = ({ isOpen, setOpen, job }: Props) => {
                 <div className="buttonContainer">
                     <Button
                         className="vacancyModalButton streetcode-custom-button"
-                        onClick={(e) => {
+                        onClick={() => {
                             window.open(EMAIL_INFO.WRITE_EMAIL_TO_US, '_blank');
-                            e.preventDefault();
                         }}
                     >
                         Відгукнутися

--- a/src/features/AdditionalPages/ContactUsPage/MainBlock/ContactBlock/ContactBlock.component.tsx
+++ b/src/features/AdditionalPages/ContactUsPage/MainBlock/ContactBlock/ContactBlock.component.tsx
@@ -18,7 +18,7 @@ const ContactBlock = () => (
         <img className="contactLogo" src={Logo} alt="" />
         <div className="contactCover">
             <div className="emailBlock">
-                <a href={EMAIL_INFO.WRITE_EMAIL_TO_US} className="emailLink">
+                <a href={EMAIL_INFO.WRITE_EMAIL_TO_US} className="emailLink" target="_blank" rel="noreferrer">
                     <div className="icon">
                         <Email />
                     </div>

--- a/src/features/AdditionalPages/PrivatePolicyPage/SubSections/SubSectionFifth/SectionFifth.component.tsx
+++ b/src/features/AdditionalPages/PrivatePolicyPage/SubSections/SubSectionFifth/SectionFifth.component.tsx
@@ -105,7 +105,9 @@ const SectionFifth = () => (
             </ul>
                 Щоб звернутися до Організації з приводу використання файлів cookie, відправте повідомлення
                 електронною поштою на адресу&nbsp;
-            <a className="link" href={EMAIL_INFO.WRITE_EMAIL_TO_US}>{EMAIL_INFO.EMAIL}</a>
+            <a className="link" href={EMAIL_INFO.WRITE_EMAIL_TO_US} target="_blank" rel="noopener noreferrer">
+                {EMAIL_INFO.EMAIL}
+            </a>
                 .
             <br />
                 Якщо користувач не включає використання файлів cookie або навмисно видаляє всі файли cookie


### PR DESCRIPTION
dev
## **Description**
**Links which should open in new tab:**
1. Vacancy modal - "Відгукнутись" button
2. "Контакти" page - clickable icon next to the streetcode gmail which leads to gmail new letter
3. "Політика конфіденційності" page - streetcode gmail which leads to gmail new letter

## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

ToDo

## Summary of change

ToDo

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
