### PR TITLE
Fix news and street code redirect

### DIFF
--- a/src/features/MainPage/NewsSlider/NewsSlider.component.tsx
+++ b/src/features/MainPage/NewsSlider/NewsSlider.component.tsx
@@ -5,8 +5,6 @@ import React, { useCallback, useState } from 'react';
 import ImagesApi from '@api/media/images.api';
 import { useAsync } from '@hooks/stateful/useAsync.hook';
 import Image from '@models/media/image.model';
-import useMobx from '@stores/root-store';
-import { toArticleRedirectClickEvent } from '@utils/googleAnalytics.unility';
 
 import NewsApi from '@/app/api/news/news.api';
 import useWindowSize from '@/app/common/hooks/stateful/useWindowSize.hook';
@@ -18,8 +16,6 @@ import Heading from '../Heading/Heading.component';
 import NewsSliderItem from './NewsSliderItem/NewsSliderItem.component';
 
 const NewsSlider = () => {
-    const { streetcodeMainPageStore, newsStore } = useMobx();
-    const { fetchNewsAll } = newsStore;
     const [news, setNews] = useState<News[]>([]);
     const [images, setImages] = useState<Image[]>([]);
 
@@ -35,15 +31,9 @@ const NewsSlider = () => {
         setDragging(false);
     }, [setDragging]);
 
-    const handleClickRedirect = (url : string) => {
-        toArticleRedirectClickEvent(url, 'main_page');
-        window.location.href = `news/${url}`;
-    };
-
     const handleOnItemClick = useCallback(
-        (e : React.MouseEvent<HTMLDivElement>, url: string) => {
+        (e : React.MouseEvent<HTMLDivElement>) => {
             if (dragging) e.stopPropagation();
-            else handleClickRedirect(url);
         },
         [dragging],
     );
@@ -95,9 +85,7 @@ const NewsSlider = () => {
                                             <div
                                                 key={news[0].id}
                                                 className="slider-item"
-                                                onClickCapture={(e) => {
-                                                    handleOnItemClick(e, news[0].url.toString());
-                                                }}
+                                                onClickCapture={handleOnItemClick}
                                             >
                                                 <NewsSliderItem news={news[0]} image={images[0]} />
                                             </div>
@@ -111,9 +99,7 @@ const NewsSlider = () => {
                                                     <div
                                                         key={item.id}
                                                         className="slider-item"
-                                                        onClickCapture={(e) => {
-                                                            handleOnItemClick(e, item.url.toString());
-                                                        }}
+                                                        onClickCapture={handleOnItemClick}
                                                     >
                                                         <NewsSliderItem news={item} image={images[index]} />
                                                     </div>

--- a/src/features/MainPage/NewsSlider/NewsSliderItem/NewsSliderItem.component.tsx
+++ b/src/features/MainPage/NewsSlider/NewsSliderItem/NewsSliderItem.component.tsx
@@ -1,6 +1,5 @@
 import './NewsSliderItem.styles.scss';
 
-import { useMediaQuery } from 'react-responsive';
 import { useNavigate } from 'react-router-dom';
 import CardText from '@components/CardText/CardText.component';
 import dayjs from 'dayjs';
@@ -16,13 +15,15 @@ interface Props {
 }
 
 const NewsSliderItem = ({ news, image }: Props) => {
-    const isMobileOrTablet = useMediaQuery({
-        query: '(max-width: 1024px)',
-    });
-
     const navigate = useNavigate();
     const historyState = { fromPage: 'main_page' };
-    const handleClickRedirect = () => navigate(news.url.toString(), { state: historyState });
+    const newsUrl = news.url.toString();
+    const handleClickRedirect = (e: React.MouseEvent<HTMLDivElement>) => {
+        // if we click "До новини" link, we don't want to redirect to news page again
+        if (!(e.target as HTMLLinkElement)?.href?.includes(newsUrl)) {
+            navigate(`/news/${newsUrl}`, { state: historyState });
+        }
+    };
 
     const tempElement = document.createElement('div');
     tempElement.innerHTML = news?.text;
@@ -41,7 +42,7 @@ const NewsSliderItem = ({ news, image }: Props) => {
 
     return (
         <div className="newsSliderItem">
-            <div className="newsMainPage" onClick={isMobileOrTablet ? handleClickRedirect : undefined}>
+            <div className="newsMainPage" onClick={handleClickRedirect}>
                 <div className="newsPageImgContainer">
                     <img
                         key={image?.id}
@@ -54,7 +55,7 @@ const NewsSliderItem = ({ news, image }: Props) => {
                     <div className="newsContainer">
                         <div className="subContainer">
                             <CardText
-                                moreBtnAsLink={{ link: news.url.toString(), state: historyState }}
+                                moreBtnAsLink={{ link: `/news/${newsUrl}`, state: historyState }}
                                 moreBtnText="До новини"
                                 title={news?.title}
                                 text={htmlReactParser(cleanText?.substring(0, 800)) as string}

--- a/src/features/MainPage/StreetcodeSlider/StreetcodeSliderItem/StreetcodeSliderItem.component.tsx
+++ b/src/features/MainPage/StreetcodeSlider/StreetcodeSliderItem/StreetcodeSliderItem.component.tsx
@@ -20,9 +20,12 @@ const StreetcodeSliderItem = ({ streetcode, image }: Props) => {
 
     const navigate = useNavigate();
     const historyState = { fromPage: 'main_page' };
-    const handleClickRedirect = () => {
-        if (streetcode.transliterationUrl) {
-            navigate(streetcode.transliterationUrl, { state: historyState });
+    const handleClickRedirect = (e: React.MouseEvent<HTMLDivElement>) => {
+        const streetcodeUrl = streetcode.transliterationUrl;
+
+        // if we click "До стріткоду" link, we don't want to redirect to streetcode page again
+        if (!(e.target as HTMLLinkElement)?.href?.includes(streetcodeUrl)) {
+            navigate(streetcodeUrl, { state: historyState });
         }
     };
 


### PR DESCRIPTION
Please check the ability to "go back" from streetcode and news page when you open them from main page (with help of streetcodeSliderItem and newsSliderItem).

