### PR TITLE
Fix layout bug

### DIFF
--- a/src/features/AdminPage/PartnersPage/Partners.styles.scss
+++ b/src/features/AdminPage/PartnersPage/Partners.styles.scss
@@ -14,6 +14,7 @@
         @include mut.sized(80%);
 
         .partners-table-logo{
+            max-width: 90%;
             height: f.pxToRem(40px);
             margin: 0;
             padding: 0


### PR DESCRIPTION
Open admin panel and check if the last tab in news tab is like on the screenshot below: 

<img width="1440" alt="Screenshot 2024-01-31 at 10 48 15 AM" src="https://github.com/ita-social-projects/StreetCode_Client/assets/91199925/d35ecd9a-977c-4590-b007-0727681798c0">

The image doesn't overflow the table as on stage env