### PR TITLE
add caching to streetcode-slider

### DIFF
--- a/src/app/api/streetcode/streetcodes.api.ts
+++ b/src/app/api/streetcode/streetcodes.api.ts
@@ -27,12 +27,16 @@ const StreetcodesApi = {
 
     getAllMainPage: () => Agent.get<StreetcodeMainPage[]>(`${API_ROUTES.STREETCODES.GET_ALL_MAINPAGE}`),
 
-    getPageMainPage: (page: number, pageSize: number, args: any) => Agent
+    getPageMainPage: (page: number, pageSize: number) => Agent
         .get<StreetcodeMainPage[]>(
             `${API_ROUTES.STREETCODES.GET_PAGE_MAINPAGE}`,
-            new URLSearchParams(Object.entries({ page: page.toString(),
-                                                 pageSize: pageSize.toString(),
-                                                 shuffleSeed: args.shuffleSeed.toString() })),
+            new URLSearchParams(Object.entries(
+                {
+                    page: page.toString(),
+                    pageSize: pageSize.toString(),
+                    shuffleSeed: '1',
+                },
+            )),
         ),
 
     getAllCatalog: (page: number, count: number) => Agent

--- a/src/features/MainPage/StreetcodeSlider/StreetcodeSlider.component.tsx
+++ b/src/features/MainPage/StreetcodeSlider/StreetcodeSlider.component.tsx
@@ -7,6 +7,7 @@ import ImagesApi from '@api/media/images.api';
 import SlickSlider from '@features/SlickSlider/SlickSlider.component';
 import { useAsync } from '@hooks/stateful/useAsync.hook';
 import Image from '@models/media/image.model';
+import useMobx from '@stores/root-store';
 
 import StreetcodesApi from '@/app/api/streetcode/streetcodes.api';
 import useWindowSize from '@/app/common/hooks/stateful/useWindowSize.hook';
@@ -17,12 +18,10 @@ import { StreetcodeMainPage } from '@/models/streetcode/streetcode-types.model';
 import STREETCODE_SLIDER_PROPS from './constants/streetcodeSliderProps.constant';
 import StreetcodeSliderItem from './StreetcodeSliderItem/StreetcodeSliderItem.component';
 
-const DEFAULT_STREETCODE_CARDS_AMOUNT = 32;
+const DEFAULT_STREETCODE_CARDS_AMOUNT = 10;
 
 const StreetcodeSlider = () => {
-    const [streetcodes, setStreetcodes] = useState<StreetcodeMainPage[]>([]);
-    const [images, setImages] = useState<Image[]>([]);
-    const loading = useRef(false);
+    const { imagesStore, streetcodeMainPageStore } = useMobx();
 
     const windowsize = useWindowSize();
     if (windowsize.width <= 1024 && windowsize.width >= 768) STREETCODE_SLIDER_PROPS.centerMode = true;
@@ -30,56 +29,8 @@ const StreetcodeSlider = () => {
     if (windowsize.width <= 1024 && windowsize.width >= 768) STREETCODE_SLIDER_PROPS.initialSlide = 1;
     if (windowsize.width <= 768) STREETCODE_SLIDER_PROPS.variableWidth = false;
 
-    useAsync(async () => {
-        const shuffleSeed = Math.floor(Date.now() / 1000);
-        const { fetchNextPage } = paginateRequest(3, StreetcodesApi.getPageMainPage, { shuffleSeed });
-
-        let streetcodesAmount: number;
-        if (!loading.current) {
-            loading.current = true;
-            try {
-                streetcodesAmount = await StreetcodesApi.getCount(true);
-            } catch (e: any) {
-                streetcodesAmount = DEFAULT_STREETCODE_CARDS_AMOUNT;
-            }
-
-            const emptyStreetcodes = Array(streetcodesAmount).fill({});
-            setStreetcodes(emptyStreetcodes);
-
-            while (true) {
-                try {
-                    const [newStreetcodes, startIdx, endIdx] = await fetchNextPage();
-                    // eslint-disable-next-line @typescript-eslint/no-loop-func
-                    setStreetcodes((prevState) => {
-                        // replace empty objects to fetched streetcode
-                        const newState = [
-                            ...prevState.slice(0, startIdx),
-                            ...newStreetcodes,
-                            ...prevState.slice(endIdx),
-                        ];
-
-                        return newState;
-                    });
-
-                    const newImages: Image[] = [];
-                    const promises = [];
-
-                    // eslint-disable-next-line no-plusplus
-                    for (let i = 0; i < newStreetcodes.length; i++) {
-                        promises.push(ImagesApi.getById(newStreetcodes[i].imageId).then((img) => {
-                            newImages[i] = img;
-                        }));
-                    }
-
-                    await Promise.all(promises).then(() => {
-                        setImages((prevState) => [...prevState, ...newImages].slice(0, streetcodesAmount));
-                    });
-                } catch (error: unknown) {
-                    break;
-                }
-            }
-        }
-    });
+    streetcodeMainPageStore.fetchStreetcodesMainPage(1, DEFAULT_STREETCODE_CARDS_AMOUNT);
+    imagesStore.fetchImages(streetcodeMainPageStore.getStreetcodesArray || []);
 
     return (
         <div>
@@ -89,14 +40,14 @@ const StreetcodeSlider = () => {
                         <div className="blockCenter">
                             <div className="streetcodeSliderContent">
                                 {
-                                    streetcodes.length > 0
+                                    streetcodeMainPageStore.getStreetcodesArray.length > 0
                                         ? (
                                             <SlickSlider {...STREETCODE_SLIDER_PROPS}>
-                                                {streetcodes.map((item, index) => (
+                                                {streetcodeMainPageStore.getStreetcodesArray.map((item, index) => (
                                                     <div key={item.id} className="slider-item">
                                                         <StreetcodeSliderItem
                                                             streetcode={item}
-                                                            image={images[index]}
+                                                            image={imagesStore.getImage(item.imageId)}
                                                         />
                                                     </div>
                                                 ))}


### PR DESCRIPTION
Please check if no logic on admin panel isn't broken (Create, Delete, Update - on Streetcodes)

Also, if you visit main page and then go to some of the streetcodes (or any other subpage) and then click 'go back' browser arrow you should see streetcode slider with the data right away