### PR TITLE
feat: added arrows on news/team blocks

### DIFF
--- a/src/assets/sass/variables/_variables.colors.scss
+++ b/src/assets/sass/variables/_variables.colors.scss
@@ -39,7 +39,7 @@ $base-arrow-filter-color: invert(95%) sepia(90%) saturate(0%)
 $active-arrow-filter-color:  invert(88%) sepia(0%) saturate(0%) 
      hue-rotate(219deg) brightness(91%) contrast(88%);
 $selected-arrow-filter-color: invert(38%) sepia(0%) saturate(0%)
-     hue-rotate(143deg) brightness(80%) contrast(81%);
+     hue-rotate(143deg) brightness(140%) contrast(81%);
 $hovered-btn-box-shadow: 0 2px 15px rgba(61, 0, 0, .25) !important;
 
 $card-scrollbar-track-color: #DEDCDC !important;

--- a/src/features/MainPage/InstagramBlock/InstagramBlock.component.tsx
+++ b/src/features/MainPage/InstagramBlock/InstagramBlock.component.tsx
@@ -31,7 +31,7 @@ const InstagramBlock = () => {
         variableWidth: true,
         swipeOnClick: false,
         slidesToShow: 4,
-        dots: windowSize.width < 1024,
+        dots: windowSize.width <= 1024,
         arrows: windowSize.width > 1024,
         slidesToScroll: 1,
     };
@@ -55,7 +55,7 @@ const InstagramBlock = () => {
                 <div className="InstagramBlock">
                     <Heading blockName="Ми в Інсті" buttonName="Зацінити інстаграм" setActionOnClick={handleClick} />
                     <div className="sliderContainer">
-                        <BlockSlider {...sliderProps}>
+                        <BlockSlider secondPreset={true} {...sliderProps}>
                             {sliderItems}
                         </BlockSlider>
                         {windowSize.width <= 480 && (

--- a/src/features/MainPage/InstagramBlock/InstagramBlock.styles.scss
+++ b/src/features/MainPage/InstagramBlock/InstagramBlock.styles.scss
@@ -9,46 +9,9 @@
 .InstagramBlock {
     .sliderContainer {
         .slick-slider {
-            .slick-arrow {
-                top: 43%;
-                @include mut.sized(68px, 101px);
-            }
-
-            .slick-prev,
-            .slick-next {
-                filter: none !important;
-            }
-
-            .slick-prev {
-                left: 20px !important;
-
-                &::before {
-                    content: url("@assets/images/utils/LeftSmallSliderArrow.svg");
-                    opacity: 0.9;
-                    filter: none;
-                }
-
-                &:hover::before {
-                    opacity: 1.0;
-                }
-            }
 
             .slick-dots {
                 bottom: f.pxToRem(3px) !important;
-            }
-
-            .slick-next {
-                right: 20px !important;
-
-                &::before {
-                    content: url("@assets/images/utils/RightSmallSliderArrow.svg");
-                    opacity: 0.8;
-                    filter: none;
-                }
-
-                &:hover::before {
-                    opacity: 1.0;
-                }
             }
         }
 

--- a/src/features/MainPage/NewsSlider/NewsSlider.component.tsx
+++ b/src/features/MainPage/NewsSlider/NewsSlider.component.tsx
@@ -67,8 +67,11 @@ const NewsSlider = () => {
                                             </div>
                                         ) : (
                                             <SlickSlider
+                                                secondPreset={true}
                                                 beforeChange={handleBeforeChange}
                                                 afterChange={handleAfterChange}
+                                                dots={ windowSize.width <= 1024}
+                                                arrows={ windowSize.width > 1024}
                                                 {...NEWS_SLIDER_PROPS}
                                             >
                                                 {newsStore.NewsArray.map((item, index) => (

--- a/src/features/MainPage/NewsSlider/constants/newsSliderProps.constant.ts
+++ b/src/features/MainPage/NewsSlider/constants/newsSliderProps.constant.ts
@@ -2,8 +2,6 @@ const NEWS_SLIDER_PROPS = {
     touchAction: 'pan-y',
     touchThreshold: 25,
     transform: 'translateZ(0)',
-    arrows: false,
-    dots: true,
     infinite: true,
     variableWidth: true,
     slidesToShow: 1,

--- a/src/features/MainPage/TeamSlider/TeamComponent.component.tsx
+++ b/src/features/MainPage/TeamSlider/TeamComponent.component.tsx
@@ -26,7 +26,7 @@ const TeamComponent = () => {
         touchAction: 'pan-y',
         touchThreshold: 25,
         transform: 'translateZ(0)',
-        arrows: false,
+        arrows: true,
         centerMode: false,
         centerPadding: '-5px',
         dots: false,
@@ -39,6 +39,7 @@ const TeamComponent = () => {
     const windowsize = useWindowSize();
     if (windowsize.width <= 1024)
     {
+        props.arrows = false;
         props.dots = true;
         if (windowsize.width >= 768) props.centerMode = true;
     }
@@ -72,6 +73,7 @@ const TeamComponent = () => {
                         <div className="blockCenter">
                             <div className="mainContent">
                                 <SlickSlider
+                                    secondPreset={true}
                                     {...props}
                                 >
                                     {team.map((member, index) => (

--- a/src/features/SlickSlider/SlickSlider.component.tsx
+++ b/src/features/SlickSlider/SlickSlider.component.tsx
@@ -5,10 +5,12 @@ import Slider from 'react-slick';
 
 import SliderProps, { defaultSliderProps } from './index';
 
+import classNames from 'classnames'
 const GenericSlider: FC<SliderProps> = ({
     children,
     onClick,
     swipeOnClick,
+    secondPreset=false,
     ...sliderProps
 }) => {
     const sliderRef = useRef<Slider>(null);
@@ -26,12 +28,17 @@ const GenericSlider: FC<SliderProps> = ({
         }
     }, [onClick, swipeOnClick]);
 
+    const classProps = classNames(
+        {'nonInfiniteSlider' : !sliderProps.infinite},
+        {'secondPreset' : secondPreset}
+    )
+
     return (
         <div className="sliderClass">
             <Slider
                 ref={sliderRef}
                 {...sliderProps}
-                className={!sliderProps.infinite ? 'nonInfiniteSlider' : ''}
+                className={classProps}
             >
                 {children?.map((slide, idx) => (
                     <div className="slider-item-container" key={idx}>

--- a/src/features/SlickSlider/SlickSlider.styles.scss
+++ b/src/features/SlickSlider/SlickSlider.styles.scss
@@ -13,7 +13,7 @@
     @include mut.sized(40px, 58px);
     $path: "@assets/images/utils/#{$direction}DefaultSliderArrow.svg";
     content: url($path);
-    opacity: 1 !important;
+    opacity: 1;
 }
 
 
@@ -92,7 +92,49 @@ li.slick-active button:before {
     }
 }
 
+.secondPreset{
 
+    .slick-arrow {
+        top: 43%;
+        @include mut.sized(68px, 101px);
+    }
+
+    .slick-prev,
+    .slick-next {
+        filter: none !important;
+    }
+
+    .slick-prev {
+        left: 20px !important;
+
+        &::before {
+            content: url("@assets/images/utils/LeftSmallSliderArrow.svg");
+            opacity: 0.9;
+            filter: none;
+        }
+
+        &:hover::before {
+            opacity: 1.0;
+            filter: none;
+        }
+    }
+
+    .slick-next {
+        right: 20px !important;
+
+        &::before {
+            content: url("@assets/images/utils/RightSmallSliderArrow.svg");
+            opacity: 0.9;
+            filter: none;
+        }
+
+        &:hover::before {
+            opacity: 1.0;
+            filter: none;
+        }
+    }
+
+}
 
 @media screen and (max-width:1024px) {
     .slick-next,

--- a/src/features/SlickSlider/index.ts
+++ b/src/features/SlickSlider/index.ts
@@ -6,6 +6,7 @@ export default interface SliderProps extends SliderWithoutChildren {
     onClick?: (index: number) => void;
     swipeOnClick?: boolean;
     children: JSX.Element[];
+    secondPreset?: boolean;
 }
 
 export const defaultSliderProps: SliderWithoutChildren = {


### PR DESCRIPTION
dev
## Github

* [Main Github ticket](https://github.com/orgs/ita-social-projects/projects/21/views/10?sliceBy%5Bvalue%5D=Shossy&pane=issue&itemId=49024575)

## Summary of issue

Navigational arrows weren't displayed on "Команда","Новини" blocks

## Summary of change

Copied approach from Instagram block and used it in default slick slider as additional stiles invoked when secondPreset parameter set to true

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
