### PR TITLE
feat: fixed colors on arrows on ArtGallery full-screen view

### DIFF
--- a/src/app/common/components/modals/Lightbox/LightboxComponent.styles.scss
+++ b/src/app/common/components/modals/Lightbox/LightboxComponent.styles.scss
@@ -8,13 +8,13 @@
     @include mut.sized(40px, 58px);
     @include mut.bg-image("@assets/images/utils/#{$direction}DefaultSliderArrow.svg");
     position: absolute;
-
+    filter: c.$base-lightbox-arrow-filter-color;
     .yarl__icon {
         @include mut.colored(c.$transparent-color, c.$transparent-color);
     }
 
     &:hover {
-        filter: brightness(60%);
+        filter: c.$hovered-lightbox-arrow-filter-color;
     }
 }
 
@@ -65,13 +65,11 @@
         .yarl__navigation_prev {
             @include slick-arrow-lightbox(Left);
             left: pxToRem(30px) !important;
-            filter: brightness(35%);
         }
 
         .yarl__navigation_next {
             @include slick-arrow-lightbox(Right);
             right: pxToRem(30px) !important;
-            filter: brightness(35%);
         }
     }
 

--- a/src/assets/sass/variables/_variables.colors.scss
+++ b/src/assets/sass/variables/_variables.colors.scss
@@ -40,6 +40,10 @@ $active-arrow-filter-color:  invert(88%) sepia(0%) saturate(0%)
      hue-rotate(219deg) brightness(91%) contrast(88%);
 $selected-arrow-filter-color: invert(38%) sepia(0%) saturate(0%)
      hue-rotate(143deg) brightness(80%) contrast(81%);
+$base-lightbox-arrow-filter-color: invert(32%) sepia(0%) saturate(8%) 
+     hue-rotate(220deg) brightness(90%) contrast(89%);
+$hovered-lightbox-arrow-filter-color: invert(63%) sepia(0%) saturate(242%)
+     hue-rotate(257deg) brightness(91%) contrast(95%);
 $hovered-btn-box-shadow: 0 2px 15px rgba(61, 0, 0, .25) !important;
 
 $card-scrollbar-track-color: #DEDCDC !important;


### PR DESCRIPTION
dev
## Github

* [Main Github ticket](https://github.com/orgs/ita-social-projects/projects/21/views/10?sliceBy%5Bvalue%5D=Shossy&pane=issue&itemId=61100382)

## Summary of issue

Arrows are invisible on ArtGallery fullscreen size

## Summary of change

Changed colors of arrows according to production version

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
