### PR TITLE
Instagram slider required extra efford to swipe

### DIFF
--- a/src/features/MainPage/InstagramBlock/InstagramBlock.component.tsx
+++ b/src/features/MainPage/InstagramBlock/InstagramBlock.component.tsx
@@ -27,6 +27,9 @@ const InstagramBlock = () => {
     const windowSize = useWindowSize();
 
     const sliderProps = {
+        touchAction: 'pan-y',
+        touchThreshold: 25,
+        transform: 'translateZ(0)',
         infinite: true,
         variableWidth: true,
         swipeOnClick: false,


### PR DESCRIPTION
Changed slider props to the same, as in team slider, so that it will be easier to swipe.