### PR TITLE
Feature/issue 1463

### DIFF
--- a/src/features/AdminPage/NewStreetcode/MainNewStreetcode.component.tsx
+++ b/src/features/AdminPage/NewStreetcode/MainNewStreetcode.component.tsx
@@ -317,8 +317,13 @@ const NewStreetcode = () => {
                 id: inputInfo?.id ?? 0,
                 title: inputInfo?.title,
                 textContent: inputInfo?.textContent ?? " ",
-                additionalText: inputInfo?.additionalText === '<p>Текст підготовлений спільно з</p>'
-                    ? '' : inputInfo?.additionalText,
+                additionalText:
+                    inputInfo?.textContent !== "<p><br></p>"
+                    ? inputInfo?.additionalText ===
+                        "<p>Текст підготовлений спільно з</p>"
+                        ? ""
+                        : inputInfo?.additionalText
+                    : "",
                 streetcodeId: parseId,
             };
             validateQuillTexts(text.textContent, text.additionalText);

--- a/src/features/AdminPage/NewStreetcode/TextBlock/TextForm/AdditionTextBlock/AdditionalTextBlockAdminForm.component.tsx
+++ b/src/features/AdminPage/NewStreetcode/TextBlock/TextForm/AdditionTextBlock/AdditionalTextBlockAdminForm.component.tsx
@@ -2,7 +2,7 @@
 /* eslint-disable react/jsx-props-no-multi-spaces */
 
 import { observer } from 'mobx-react-lite';
-import { useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import ReactQuill from 'react-quill';
 
 import FormItem from 'antd/es/form/FormItem';
@@ -23,9 +23,21 @@ const AdditionalTextBlockAdminForm = ({
 }: Props) => {
     const maxLength = character_limit || 200;
     const editorRef = useRef<ReactQuill | null>(null);
+    const [isTextContentEmpty, setIsTextContentEmpty] = useState(true);
+    const [isTitleEmpty, setIsTitleEmpty] = useState(true);
+
+    useEffect(() => {
+        setIsTextContentEmpty(!inputInfo?.textContent || inputInfo.textContent === "<p><br></p>");
+        console.log(inputInfo?.textContent)
+      }, [inputInfo?.textContent]);
+
+    useEffect(() => {
+        setIsTitleEmpty(!inputInfo?.title || inputInfo.title === "");
+      }, [inputInfo?.title]);
 
     return (
         <FormItem label="Авторство">
+            <div className={isTextContentEmpty || isTitleEmpty ? "disabled" : ""}>
             <Editor
                 qRef={editorRef}
                 value={(text === undefined || text === '') ? 'Текст підготовлений спільно з' : text}
@@ -34,7 +46,9 @@ const AdditionalTextBlockAdminForm = ({
                     onChange('additionalText', editor);
                 }}
                 maxChars={maxLength}
+                readOnly={isTitleEmpty || isTextContentEmpty}
             />
+            </div>
         </FormItem>
     );
 };

--- a/src/features/AdminPage/NewStreetcode/TextBlock/TextForm/AdditionTextBlock/AdditionalTextBlockAdminForm.component.tsx
+++ b/src/features/AdminPage/NewStreetcode/TextBlock/TextForm/AdditionTextBlock/AdditionalTextBlockAdminForm.component.tsx
@@ -28,7 +28,6 @@ const AdditionalTextBlockAdminForm = ({
 
     useEffect(() => {
         setIsTextContentEmpty(!inputInfo?.textContent || inputInfo.textContent === "<p><br></p>");
-        console.log(inputInfo?.textContent)
       }, [inputInfo?.textContent]);
 
     useEffect(() => {


### PR DESCRIPTION
Issue:

Author block is not disabled when no main text is provided. You can create TextBlock of StreetCode that contains only title and author.

Solve:

Added check for existence of title and textContent