### PR TITLE
Fixed line height to get rid of dots

### DIFF
--- a/src/app/common/components/ArtGallery/components/BaseArtGallerySlide.styles.scss
+++ b/src/app/common/components/ArtGallery/components/BaseArtGallerySlide.styles.scss
@@ -60,6 +60,7 @@
         @include vnd.vendored(transition, 'all .5s ease');
         @include mut.rounded( $bottom-right: 30px, $bottom-left: 30px);
         padding: pxToRem(11px) pxToRem(21px);
+        line-height: 1.6rem;
     }
 
     .imgTitle {


### PR DESCRIPTION
Found out that the reason for dots under the title in art gallery is unset line height.
