### PR TITLE
slick slider dots problem resolved

### DIFF
--- a/src/app/api/media/streetcode-art.api.ts
+++ b/src/app/api/media/streetcode-art.api.ts
@@ -15,6 +15,10 @@ const StreetcodeArtApi = {
         `${API_ROUTES.STREETCODE_ART_SLIDES.GET_SLIDES_BY_STREETCODE_ID}/${streetcodeId}`,
         new URLSearchParams(Object.entries({ fromSlideN: startFromSlide.toString(), amountOfSlides: amountOfSlides.toString() })),
     ),
+
+    getAllCountByStreetcodeId: (streetcodeId: number) => Agent.get<number>(
+        `${API_ROUTES.STREETCODE_ART_SLIDES.GET_ALL_COUNT_BY_STREETCODE_ID}/${streetcodeId}`,
+    ),
 };
 
 export default StreetcodeArtApi;

--- a/src/app/common/components/ArtGallery/ArtGalleryBlock.component.tsx
+++ b/src/app/common/components/ArtGallery/ArtGalleryBlock.component.tsx
@@ -46,7 +46,7 @@ const ArtGallery = ({
       errorStreetCodeId
     },
   } = useStreetcodeDataContext();
-  const { fetchNextArtSlidesByStreetcodeId, streetcodeArtSlides, amountOfSlides, setStartingSlideAndId } = streetcodeArtSlideStore;
+  const { fetchAllToDefaultTemplate, fetchAllArtSlidesByStreetcodeId, fetchNextArtSlidesByStreetcodeId, streetcodeArtSlides, amountOfSlides, setStartingSlideAndId } = streetcodeArtSlideStore;
   const { streetcodeArtSlides: templateArtSlides } = artGalleryTemplateStore;
   const [slickProps, setSlickProps] = useState<SliderSettings>(SLIDER_PROPS);
   const [isTemplateSelected, setIsTemplateSelected] = useState(title === "Шаблони");
@@ -90,18 +90,33 @@ const ArtGallery = ({
   async function fetchData() {
     if (streetcodeIdValidAndFetchingRequired()) {
       secondRender.current = true;
-      let currentSlide = 0;
-      while (currentSlide < MAX_SLIDES_AMOUNT) {
-        try {
-          // eslint-disable-next-line no-await-in-loop
-          await fetchNextArtSlidesByStreetcodeId(getStreetCodeId !== -1 ? getStreetCodeId : parseId);
-          if (isFillArtsStore) {
-            copyArtsFromSlidesToStore();
-          }
+      if (isFillArtsStore) {
+        await fetchAllToDefaultTemplate(getStreetCodeId !== -1 ? getStreetCodeId : parseId);
 
-          currentSlide += amountOfSlides;
-        } catch (error: unknown) {
-          currentSlide = MAX_SLIDES_AMOUNT;
+        let currentSlide = 0;
+        while (currentSlide < MAX_SLIDES_AMOUNT) {
+          try {
+            // eslint-disable-next-line no-await-in-loop
+            await fetchAllArtSlidesByStreetcodeId(getStreetCodeId !== -1 ? getStreetCodeId : parseId, currentSlide);
+            
+            currentSlide += amountOfSlides;
+          } catch (error: unknown) {
+            currentSlide = MAX_SLIDES_AMOUNT;
+          }
+        }
+        
+        copyArtsFromSlidesToStore();
+      } else {
+        let currentSlide = 0;
+        while (currentSlide < MAX_SLIDES_AMOUNT) {
+          try {
+            // eslint-disable-next-line no-await-in-loop
+            await fetchNextArtSlidesByStreetcodeId(getStreetCodeId !== -1 ? getStreetCodeId : parseId);
+            
+            currentSlide += amountOfSlides;
+          } catch (error: unknown) {
+            currentSlide = MAX_SLIDES_AMOUNT;
+          }
         }
       }
       setStartingSlideAndId(getStreetCodeId);

--- a/src/app/common/components/ArtGallery/constants/allSlidesTemplates.ts
+++ b/src/app/common/components/ArtGallery/constants/allSlidesTemplates.ts
@@ -6,6 +6,32 @@ import { StreetcodeArtSlideAdmin } from '@/models/media/streetcode-art-slide.mod
 
 // eslint-disable-next-line max-len
 const TEMPLATE_IMAGE_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAUcAAADoCAYAAAB8dCbkAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAMPSURBVHhe7cixDcAwAMOw/P90mr36wBTARed1AfjJCbAuJ8C6nADrcgKsywmwLifAupwA63ICrMsJsC4nwLqcAOtyAqzLCbAuJ8C6nADrcgKsywmwLifAupwA63ICrMsJsC4nwLqcAOtyAqzLCbAuJ8C6nADrcgKsywmwLifAupwA63ICrMsJsC4nwLqcAOtyAqzLCbAuJ8C6nADrcgKsywmwLifAupwA63ICrMsJsC4nwLqcAOtyAqzLCbAuJ8C6nADrcgKsywmwLifAupwA63ICrMsJsC4nwLqcAOtyAqzLCbAuJ8C6nADrcgKsywmwLifAupwA63ICrMsJsC4nwLqcAOtyAqzLCbAuJ8C6nADrcgKsywmwLifAupwA63ICrMsJsC4nwLqcAOtyAqzLCbAuJ8C6nADrcgKsywmwLifAupwA63ICrMsJsC4nwLqcAOtyAqzLCbAuJ8C6nADrcgKsywmwLifAupwA63ICrMsJsC4nwLqcAOtyAqzLCbAuJ8C6nADrcgKsywmwLifAupwA63ICrMsJsC4nwLqcAOtyAqzLCbAuJ8C6nADrcgKsywmwLifAupwA63ICrMsJsC4nwLqcAOtyAqzLCbAuJ8C6nADrcgKsywmwLifAupwA63ICrMsJsC4nwLqcAOtyAqzLCbAuJ8C6nADrcgKsywmwLifAupwA63ICrMsJsC4nwLqcAOtyAqzLCbAuJ8C6nADrcgKsywmwLifAupwA63ICrMsJsC4nwLqcAOtyAqzLCbAuJ8C6nADrcgKsywmwLifAupwA63ICrMsJsC4nwLqcAOtyAqzLCbAuJ8C6nADrcgKsywmwLifAupwA63ICrMsJsC4nwLqcAOtyAqzLCbAuJ8C6nADrcgKsywmwLifAupwA63ICrMsJsC4nwLqcAOtyAqzLCbAuJ8C6nADrcgKsywmwLifAupwA63ICrMsJsC4nwLqcAOtyAqzLCbAuJ8C6nADrcgKsywmwLifAupwA63ICrMsJsC4nwLqcAOtyAqzLCbAuJ8C6nADDzv0A9XdA8gKGinIAAAAASUVORK5CYII=';
+const TEMPLATE_WHITE_IMAGE_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAUcAAADoCAYAAAB8dCbkAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAAEnQAABJ0Ad5mH3gAAAL2SURBVHhe7dSxEYAwEMCwh/13JhQU4eIRpMYb+HpeA8DP/RWAjTkCBHMECOYIEMwRIJgjQDBHgGCOAMEcAYI5AgRzBAjmCBDMESCYI0AwR4BgjgDBHAGCOQIEcwQI5ggQzBEgmCNAMEeAYI4AwRwBgjkCBHMECOYIEMwRIJgjQDBHgGCOAMEcAYI5AgRzBAjmCBDMESCYI0AwR4BgjgDBHAGCOQIEcwQI5ggQzBEgmCNAMEeAYI4AwRwBgjkCBHMECOYIEMwRIJgjQDBHgGCOAMEcAYI5AgRzBAjmCBDMESCYI0AwR4BgjgDBHAGCOQIEcwQI5ggQzBEgmCNAMEeAYI4AwRwBgjkCBHMECOYIEMwRIJgjQDBHgGCOAMEcAYI5AgRzBAjmCBDMESCYI0AwR4BgjgDBHAGCOQIEcwQI5ggQzBEgmCNAMEeAYI4AwRwBgjkCBHMECOYIEMwRIJgjQDBHgGCOAMEcAYI5AgRzBAjmCBDMESCYI0AwR4BgjgDBHAGCOQIEcwQI5ggQzBEgmCNAMEeAYI4AwRwBgjkCBHMECOYIEMwRIJgjQDBHgGCOAMEcAYI5AgRzBAjmCBDMESCYI0AwR4BgjgDBHAGCOQIEcwQI5ggQzBEgmCNAMEeAYI4AwRwBgjkCBHMECOYIEMwRIJgjQDBHgGCOAMEcAYI5AgRzBAjmCBDMESCYI0AwR4BgjgDBHAGCOQIEcwQI5ggQzBEgmCNAMEeAYI4AwRwBgjkCBHMECOYIEMwRIJgjQDBHgGCOAMEcAYI5AgRzBAjmCBDMESCYI0AwR4BgjgDBHAGCOQIEcwQI5ggQzBEgmCNAMEeAYI4AwRwBgjkCBHMECOYIEMwRIJgjQDBHgGCOAMEcAYI5AgRzBAjmCBDMESCYI0AwR4BgjgDBHAGCOQIEcwQI5ggQzBEgmCNAMEeAYI4AwRwBgjkCBHMECOYIEMwRIJgjQDBHgGCOAMEcAYI5AgRzBAjmCBDMESCYI0AwR4DDzAKUswXMuvXEwwAAAABJRU5ErkJggg==';
+
+const SLIDE_TEMPLATE: StreetcodeArtSlideAdmin = {
+    index: 1,
+    template: ArtSlideTemplateEnum.OneToFour,
+    streetcodeArts: [
+        {
+            index: 1,
+            art: {
+                id: 0,
+                imageId: 0,
+                image: {
+                    id: 0,
+                    base64: TEMPLATE_WHITE_IMAGE_BASE64,
+                    blobName: 'name',
+                    mimeType: 'image/svg',
+                },
+            },
+        },
+    ],
+    modelState: ModelState.Created,
+}
+
+const bindStreetcodeIdToDefaultSlide = (streetcodeId: number) => {
+    return {...SLIDE_TEMPLATE, streetcodeId: streetcodeId} as StreetcodeArtSlideAdmin;
+}
 
 const ALL_SLIDES_TEMPLATES: StreetcodeArtSlideAdmin[] = [
     {
@@ -746,4 +772,4 @@ const EMPTY_ART_TEMPLATE = {
 }
 
 export default ALL_SLIDES_TEMPLATES;
-export { TEMPLATE_IMAGE_BASE64, EMPTY_ART_TEMPLATE };
+export { TEMPLATE_IMAGE_BASE64, EMPTY_ART_TEMPLATE, SLIDE_TEMPLATE, bindStreetcodeIdToDefaultSlide };

--- a/src/app/common/constants/api-routes.constants.ts
+++ b/src/app/common/constants/api-routes.constants.ts
@@ -149,6 +149,7 @@ export const API_ROUTES = {
     },
     STREETCODE_ART_SLIDES: {
         GET_SLIDES_BY_STREETCODE_ID: 'streetcodeArtSlide/getPageByStreetcodeId',
+        GET_ALL_COUNT_BY_STREETCODE_ID: 'streetcodeArtSlide/getAllCountByStreetcodeId',
     },
     RELATED_FIGURES: {
         GET_ALL: 'relatedFigure/getAll',

--- a/src/app/stores/streetcode-art-slide-store.ts
+++ b/src/app/stores/streetcode-art-slide-store.ts
@@ -6,6 +6,7 @@ import StreetcodeArtSlide,
     StreetcodeArtSlideAdmin,
     StreetcodeArtSlideCreateUpdate,
 } from '@models/media/streetcode-art-slide.model';
+import { bindStreetcodeIdToDefaultSlide } from '../common/components/ArtGallery/constants/allSlidesTemplates';
 
 export default class StreetcodeArtSlideStore {
     public streetcodeArtSlides: StreetcodeArtSlideAdmin[] = new Array<StreetcodeArtSlideAdmin>();
@@ -26,7 +27,7 @@ export default class StreetcodeArtSlideStore {
         const isInSlides = this.getVisibleSortedSlidesWithoutParam()?.some(
             (slide) => (slide.streetcodeArts.some(
                 (sArt) => sArt.art.id.toString() === id,
-            ) && (slide.index-1)!==except),
+            ) && (slide.index - 1) !== except),
         );
 
         return isInSlides;
@@ -63,7 +64,7 @@ export default class StreetcodeArtSlideStore {
             const arrayOfArtSlides = await StreetcodeArtApi
                 .getArtSlidesByStreetcodeId(streetcodeid, this.startFromSlide, this.amountOfSlides);
             if (arrayOfArtSlides.length !== 0) {
-                this.streetcodeArtSlides.push(...arrayOfArtSlides.map((slide:StreetcodeArtSlide) => ({
+                this.streetcodeArtSlides.push(...arrayOfArtSlides.map((slide: StreetcodeArtSlide) => ({
                     ...slide,
                     modelState: ModelState.Updated,
                     isPersisted: true,
@@ -71,6 +72,27 @@ export default class StreetcodeArtSlideStore {
                     streetcodeArts: slide.streetcodeArts.sort((a, b) => (a.index > b.index ? 1 : -1)),
                 })));
 
+                this.startFromSlide += 1;
+            } else {
+                throw new Error('No more arts to load');
+            }
+        }
+    };
+
+    public fetchAllToDefaultTemplate = async (streetcodeid: number) => {
+        const slidesCount = await StreetcodeArtApi.getAllCountByStreetcodeId(streetcodeid)
+        this.streetcodeArtSlides = new Array<StreetcodeArtSlideAdmin>(slidesCount).fill(bindStreetcodeIdToDefaultSlide(streetcodeid), 0, slidesCount)
+    }
+
+    public fetchAllArtSlidesByStreetcodeId = async (streetcodeid: number, startIndex: number) => {
+        if (!this.streetcodeWasFetched.includes(streetcodeid)) {
+            const arrayOfArtSlides = await StreetcodeArtApi
+                .getArtSlidesByStreetcodeId(streetcodeid, this.startFromSlide, this.amountOfSlides);
+            if (arrayOfArtSlides.length !== 0) {
+                arrayOfArtSlides.forEach((value) => {
+                    this.streetcodeArtSlides[startIndex] = value;
+                    startIndex++;
+                })
                 this.startFromSlide += 1;
             } else {
                 throw new Error('No more arts to load');
@@ -94,7 +116,7 @@ export default class StreetcodeArtSlideStore {
                 };
 
                 if (convertedSlide.streetcodeId === -1) {
-                // @ts-ignore
+                    // @ts-ignore
                     convertedSlide.streetcodeId = null;
                 }
 


### PR DESCRIPTION
Let me elaborate:
1. Get number of slides for specific streetcode
2. Fill streetcodeArtSlides with empty slides so the slick slider shows right number of dots
3. Then fetch ArtSlides as intended, 1 slide at a time, to reduce load time of ArtGallery
4. Swap default slide (fully white slide) with fetched slide
5. Done