### PR TITLE
Streetcode page bottom space fixed when partners is absent

### DIFF
--- a/src/features/StreetcodePage/PartnersBlock/Partners.component.tsx
+++ b/src/features/StreetcodePage/PartnersBlock/Partners.component.tsx
@@ -77,7 +77,7 @@ const PartnersComponent = () => {
                     </SlickSlider>
                 </div>
             </div>
-        ) : <></>
+        ) : <div className="height-52" />
     );
 };
 

--- a/src/features/StreetcodePage/PartnersBlock/Partners.styles.scss
+++ b/src/features/StreetcodePage/PartnersBlock/Partners.styles.scss
@@ -1,6 +1,10 @@
 @use "@sass/mixins/_utils.mixins.scss" as mut;
 @use "@sass/_utils.functions.scss" as f;
 
+.height-52 {
+    @include mut.sized(100%, 52px);
+}
+
 .partnersWrapper {
     @include mut.flex-centered();
     


### PR DESCRIPTION
Ticket [#1650](https://github.com/orgs/ita-social-projects/projects/21/views/1?pane=issue&itemId=74376032)