### PR TITLE
Hiperlinks replaced with router's Link component in Private Policy

### DIFF
--- a/src/features/AdditionalPages/PrivatePolicyPage/SubSections/SubSectionFirst/SectionFirst.component.tsx
+++ b/src/features/AdditionalPages/PrivatePolicyPage/SubSections/SubSectionFirst/SectionFirst.component.tsx
@@ -1,10 +1,12 @@
+import { Link } from "react-router-dom";
+
 const SectionFirst = () => (
     <section>
         <div className="title">1. Загальні положення</div>
         <div className="content">
             Управління платформою
             &nbsp;
-            <a className="link" href="https://streetcode.com.ua">https://www.streetcode.com.ua</a>
+            <Link className="link" to="/">www.streetcode.com.ua</Link>
             &nbsp;
             (далі — платформа)
             здійснюється Громадською організацією «Історична платформа» (ЄДРПОУ 44801186) — юридичною особою,

--- a/src/features/AdditionalPages/PrivatePolicyPage/Title/Title.component.tsx
+++ b/src/features/AdditionalPages/PrivatePolicyPage/Title/Title.component.tsx
@@ -1,5 +1,7 @@
 import './Title.styles.scss';
 
+import { Link } from 'react-router-dom';
+
 const Title = () => (
     <div className="titleContainer">
         <div className="title">
@@ -7,7 +9,7 @@ const Title = () => (
             <div className="titleBig">Політика конфіденційності</div>
             <div className="subTitle">
                 та захисту персональних даних платформи&nbsp;
-                <a className="link" href="https://streetcode.com.ua">www.streetcode.com.ua</a>
+                <Link className="link" to="/">www.streetcode.com.ua</Link>
             </div>
         </div>
         <div className="disclaimer">


### PR DESCRIPTION
* Ticket #1038


## Code reviewers

- [ ] @sashapanasiuk5 
- [ ] @Mikhail-Kolpakov 
- [ ] @ita-social-projects/734-08-streetcode 

## Summary of issue

Replace hiperlinks with router's Link component in src/features/AdditionalPages/PrivatePolicyPage/Title/Title.component.tsx

## Summary of change

Hiperlinks replaced in

- src/features/AdditionalPages/PrivatePolicyPage/Title/Title.component.tsx
- src/features/AdditionalPages/PrivatePolicyPage/SubSections/SubSectionFirst/SectionFirst.component.tsx

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
