### PR TITLE
Team members slider is highlighted when tapped

### DIFF
--- a/src/features/AboutUsPage/TeamMembers/TeamMembers.component.scss
+++ b/src/features/AboutUsPage/TeamMembers/TeamMembers.component.scss
@@ -53,6 +53,7 @@
     align-items: center;
     justify-content: center;
     margin: 0 auto;
+    -webkit-tap-highlight-color: transparent;
 }
 
 .squareParent{


### PR DESCRIPTION
* Ticket ita-social-projects/StreetCode#891

## Summary of issue

Team members slider is highlighted blue when tapped

## Summary of change

Team members slider is not highlighted when tapped

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
