### PR TITLE
Nav menu on admin panel now highlights the current section

### DIFF
--- a/src/features/AdminPage/PageBar/PageBar.component.tsx
+++ b/src/features/AdminPage/PageBar/PageBar.component.tsx
@@ -1,17 +1,17 @@
 import './PageBar.styles.scss';
 
-import { Link } from 'react-router-dom';
+import { NavLink } from 'react-router-dom';
 import FRONTEND_ROUTES from '@constants/frontend-routes.constants';
 
 const PageBar = () => (
     <div className="PageBarContainer">
         <div className="BarContainer">
-            <Link className="Link" to={FRONTEND_ROUTES.ADMIN.BASE}>Стріткоди</Link>
-            <Link className="Link" to={FRONTEND_ROUTES.ADMIN.PARTNERS}>Партнери</Link>
-            <Link className="Link" to={FRONTEND_ROUTES.ADMIN.EDITOR}>Едітор</Link>
-            <Link className="Link" to={`${FRONTEND_ROUTES.ADMIN.TEAM}`}>Команда</Link>
-            <Link className="Link" to={FRONTEND_ROUTES.ADMIN.NEWS}>Новини</Link>
-            <Link className="Link" to={FRONTEND_ROUTES.ADMIN.JOBS}>Вакансії</Link>
+            <NavLink className="Link" to={FRONTEND_ROUTES.ADMIN.BASE} end>Стріткоди</NavLink>
+            <NavLink className="Link" to={FRONTEND_ROUTES.ADMIN.PARTNERS}>Партнери</NavLink>
+            <NavLink className="Link" to={FRONTEND_ROUTES.ADMIN.EDITOR}>Едітор</NavLink>
+            <NavLink className="Link" to={`${FRONTEND_ROUTES.ADMIN.TEAM}`}>Команда</NavLink>
+            <NavLink className="Link" to={FRONTEND_ROUTES.ADMIN.NEWS}>Новини</NavLink>
+            <NavLink className="Link" to={FRONTEND_ROUTES.ADMIN.JOBS}>Вакансії</NavLink>
         </div>
     </div>
 );

--- a/src/features/AdminPage/PageBar/PageBar.styles.scss
+++ b/src/features/AdminPage/PageBar/PageBar.styles.scss
@@ -26,7 +26,11 @@
         &:focus {
             outline: none;
             box-shadow: none;
-          }
+        }
         @include vnd.vendored(transition, 'scale .3s ease');
+
+        &.active {
+            color: c.$text-red-color;
+        }
     }
 }

--- a/src/features/AdminPage/PageBar/PageBar.styles.scss
+++ b/src/features/AdminPage/PageBar/PageBar.styles.scss
@@ -31,6 +31,8 @@
 
         &.active {
             color: c.$text-red-color;
+            text-decoration: underline;
+            text-underline-offset: f.pxToRem(5px);
         }
     }
 }


### PR DESCRIPTION
* Ticket ita-social-projects/StreetCode#1707

## Summary of issue

When a user uses the admin page, he may get confused in which section he is currently in ("Стріткоди", "Партнери", "Едітор", etc.), which makes it (admin page) difficult to use. The section user is on is not highlighted in any way.

## Summary of change

Highlighting added to menu on admin panel

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
