### PR TITLE
 Prevented images from loading repeatedly.

### DIFF
--- a/src/features/AdminPage/CategoriesPage/CategoriesPage.component.tsx
+++ b/src/features/AdminPage/CategoriesPage/CategoriesPage.component.tsx
@@ -27,7 +27,7 @@ const CategoriesMainPage: React.FC = observer(() => {
             sourcesStore.fetchSrcCategoriesAll(),
         ]).then(() => {
             sourcesStore?.srcCategoriesMap.forEach((val, key) => {
-                if (val.imageId !== null && val.imageId !== undefined) {
+                if (!val.imageId && !!val.image) {
                     ImageStore.getImageById(val.imageId!).then((image) => {
                         sourcesStore.srcCategoriesMap.set(
                             key,

--- a/src/features/AdminPage/CategoriesPage/CategoriesPage.component.tsx
+++ b/src/features/AdminPage/CategoriesPage/CategoriesPage.component.tsx
@@ -27,7 +27,7 @@ const CategoriesMainPage: React.FC = observer(() => {
             sourcesStore.fetchSrcCategoriesAll(),
         ]).then(() => {
             sourcesStore?.srcCategoriesMap.forEach((val, key) => {
-                if (!val.imageId && !!val.image) {
+                if (!!val.imageId && !val.image) {
                     ImageStore.getImageById(val.imageId!).then((image) => {
                         sourcesStore.srcCategoriesMap.set(
                             key,


### PR DESCRIPTION
* Ticket ita-social-projects/StreetCode#947

## Summary of issue

There are many identical API requests for images.

## Summary of change

Prevented images from loading repeatedly.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
