### PR TITLE
Image validation added for most modals where needed

### DIFF
--- a/src/app/common/components/modals/validators/imageValidator.tsx
+++ b/src/app/common/components/modals/validators/imageValidator.tsx
@@ -1,6 +1,6 @@
 import { RuleObject } from 'rc-field-form/lib/interface';
 
-const imageValidator = (_: RuleObject, file: any): Promise<any> => {
+const imageValidator = (_: RuleObject, file: any): Promise<void> => {
     if (file) {
         let name = '';
         if (file.file) {
@@ -9,10 +9,9 @@ const imageValidator = (_: RuleObject, file: any): Promise<any> => {
             name = file.name.toLowerCase();
         }
 
-        if (name.endsWith('.jpeg')
-            || name.endsWith('.png')
-            || name.endsWith('.webp')
-            || name.endsWith('.jpg')) {
+        const allowedExtensions = ['.jpeg', '.png', '.webp', '.jpg'];
+
+        if (allowedExtensions.some((ext) => name.endsWith(ext))) {
             return Promise.resolve();
         }
 

--- a/src/app/common/components/modals/validators/imageValidator.tsx
+++ b/src/app/common/components/modals/validators/imageValidator.tsx
@@ -1,0 +1,25 @@
+import { RuleObject } from 'rc-field-form/lib/interface';
+
+const imageValidator = (_: RuleObject, file: any): Promise<any> => {
+    if (file) {
+        let name = '';
+        if (file.file) {
+            name = file.file.name.toLowerCase();
+        } else if (file.name) {
+            name = file.name.toLowerCase();
+        }
+
+        if (name.endsWith('.jpeg')
+            || name.endsWith('.png')
+            || name.endsWith('.webp')
+            || name.endsWith('.jpg')) {
+            return Promise.resolve();
+        }
+
+        return Promise.reject(new Error('Тільки файли з розширенням webp, jpeg, png, jpg дозволені!'));
+    }
+
+    return Promise.reject();
+};
+
+export default imageValidator;

--- a/src/app/common/components/modals/validators/imageValidator.tsx
+++ b/src/app/common/components/modals/validators/imageValidator.tsx
@@ -1,3 +1,4 @@
+import { SUPPORTED_IMAGE_FILE_TYPES } from '@/app/common/constants/file-types.constants';
 import { RuleObject } from 'rc-field-form/lib/interface';
 
 const imageValidator = (_: RuleObject, file: any): Promise<void> => {
@@ -20,5 +21,7 @@ const imageValidator = (_: RuleObject, file: any): Promise<void> => {
 
     return Promise.reject();
 };
+
+export const checkImageFileType = (type: string | undefined) => type && SUPPORTED_IMAGE_FILE_TYPES.includes(type);
 
 export default imageValidator;

--- a/src/app/common/constants/file-types.constants.ts
+++ b/src/app/common/constants/file-types.constants.ts
@@ -1,0 +1,6 @@
+export const SUPPORTED_IMAGE_FILE_TYPES = [
+    'image/jpeg',
+    'image/jpg',
+    'image/png',
+    'image/webp',
+];

--- a/src/features/AdminPage/CategoriesPage/CategoriesPage/CategoryAdminModal.component.tsx
+++ b/src/features/AdminPage/CategoriesPage/CategoriesPage/CategoryAdminModal.component.tsx
@@ -14,7 +14,7 @@ import Image from '@models/media/image.model';
 import { SourceCategoryAdmin } from '@models/sources/sources.model';
 import useMobx from '@stores/root-store';
 
-import imageValidator from '@/app/common/components/modals/validators/imageValidator';
+import imageValidator, { checkImageFileType } from '@/app/common/components/modals/validators/imageValidator';
 
 import {
     Button, Form, Input, message, Modal, Popover,
@@ -26,8 +26,6 @@ import base64ToUrl from '@/app/common/utils/base64ToUrl.utility';
 
 import PreviewFileModal from '../../NewStreetcode/MainBlock/PreviewFileModal/PreviewFileModal.component';
 import POPOVER_CONTENT from '../../JobsPage/JobsModal/constants/popoverContent';
-
-import { SUPPORTED_IMAGE_FILE_TYPES } from '@constants/file-types.constants';
 
 interface SourceModalProps {
     isModalVisible: boolean;
@@ -153,7 +151,7 @@ const SourceModal: React.FC<SourceModalProps> = ({
         }
     };
 
-    const checkFile = (file: UploadFile) => file.type && SUPPORTED_IMAGE_FILE_TYPES.includes(file.type);
+    const checkFile = (file: UploadFile) => checkImageFileType(file.type);
 
     const handleFileChange = async (param: UploadChangeParam<UploadFile<unknown>>) => {
         if (checkFile(param.file)) {

--- a/src/features/AdminPage/CategoriesPage/CategoriesPage/CategoryAdminModal.component.tsx
+++ b/src/features/AdminPage/CategoriesPage/CategoriesPage/CategoryAdminModal.component.tsx
@@ -27,6 +27,8 @@ import base64ToUrl from '@/app/common/utils/base64ToUrl.utility';
 import PreviewFileModal from '../../NewStreetcode/MainBlock/PreviewFileModal/PreviewFileModal.component';
 import POPOVER_CONTENT from '../../JobsPage/JobsModal/constants/popoverContent';
 
+import { SUPPORTED_IMAGE_FILE_TYPES } from '@constants/file-types.constants';
+
 interface SourceModalProps {
     isModalVisible: boolean;
     setIsModalOpen: Dispatch<SetStateAction<boolean>>;
@@ -130,9 +132,9 @@ const SourceModal: React.FC<SourceModalProps> = ({
     const handleOk = async () => {
         try {
             await form.validateFields();
-            
+
             const title = form.getFieldValue('title');
-    
+
             if (!title.trim()) {
                 message.error("Будь ласка, заповніть всі обов'язкові поля та перевірте валідність ваших даних");
                 return;
@@ -151,11 +153,7 @@ const SourceModal: React.FC<SourceModalProps> = ({
         }
     };
 
-    const checkFile = (file: UploadFile) =>
-        (file.type === 'image/jpeg')
-        || (file.type === 'image/webp')
-        || (file.type === 'image/png')
-        || (file.type === 'image/jpg');
+    const checkFile = (file: UploadFile) => file.type && SUPPORTED_IMAGE_FILE_TYPES.includes(file.type);
 
     const handleFileChange = async (param: UploadChangeParam<UploadFile<unknown>>) => {
         if (checkFile(param.file)) {

--- a/src/features/AdminPage/CategoriesPage/CategoriesPage/CategoryAdminModal.component.tsx
+++ b/src/features/AdminPage/CategoriesPage/CategoriesPage/CategoryAdminModal.component.tsx
@@ -1,4 +1,5 @@
 import '@features/AdminPage/AdminModal.styles.scss';
+import '@features/AdminPage/CategoriesPage/CategoriesPage/CategoryAdminModal.styles.scss';
 
 import CancelBtn from '@images/utils/Cancel_btn.svg';
 
@@ -13,11 +14,13 @@ import Image from '@models/media/image.model';
 import { SourceCategoryAdmin } from '@models/sources/sources.model';
 import useMobx from '@stores/root-store';
 
+import imageValidator from '@/app/common/components/modals/validators/imageValidator';
+
 import {
     Button, Form, Input, message, Modal, Popover,
     UploadFile,
 } from 'antd';
-import { UploadFileStatus } from 'antd/es/upload/interface';
+import { UploadChangeParam, UploadFileStatus } from 'antd/es/upload/interface';
 
 import base64ToUrl from '@/app/common/utils/base64ToUrl.utility';
 
@@ -124,15 +127,6 @@ const SourceModal: React.FC<SourceModalProps> = ({
         setFileList([]);
     };
 
-    const getValueFromEvent = (e: any) => {
-        if (e && e.fileList) {
-            return e.fileList;
-        } if (e && e.file && e.fileList === undefined) {
-            return [e.file];
-        }
-        return [];
-    };
-
     const handleOk = async () => {
         try {
             await form.validateFields();
@@ -156,7 +150,18 @@ const SourceModal: React.FC<SourceModalProps> = ({
             message.error("Будь ласка, заповніть всі обов'язкові поля та перевірте валідність ваших даних");
         }
     };
-    
+
+    const checkFile = (file: UploadFile) =>
+        (file.type === 'image/jpeg')
+        || (file.type === 'image/webp')
+        || (file.type === 'image/png')
+        || (file.type === 'image/jpg');
+
+    const handleFileChange = async (param: UploadChangeParam<UploadFile<unknown>>) => {
+        if (checkFile(param.file)) {
+            setFileList(param.fileList);
+        }
+    };
 
     return (
         <>
@@ -164,7 +169,7 @@ const SourceModal: React.FC<SourceModalProps> = ({
                 title={isEditing ? 'Редагувати категорію' : 'Додати нову категорію'}
                 open={isModalVisible}
                 onCancel={closeModal}
-                className="modalContainer"
+                className="modalContainer categoryModal"
                 closeIcon={(
                     <Popover content={POPOVER_CONTENT.CANCEL} trigger="hover">
                         <CancelBtn className="iconSize" onClick={handleCancel} />
@@ -183,20 +188,20 @@ const SourceModal: React.FC<SourceModalProps> = ({
                     <Form.Item
                         name="image"
                         label="Картинка: "
-                        rules={[{ required: true, message: 'Додайте зображення' }]}
-                        getValueFromEvent={getValueFromEvent}
-                        style={{ filter: 'grayscale(100%)' }}
+                        rules={[
+                            { required: true, message: 'Додайте зображення' },
+                            { validator: imageValidator },
+                        ]}
                     >
                         <FileUploader
                             greyFilterForImage
-                            onChange={(param) => {
-                                setFileList(param.fileList);
-                            }}
                             multiple={false}
                             accept=".jpeg,.png,.jpg,.webp"
                             listType="picture-card"
                             maxCount={1}
                             uploadTo="image"
+                            beforeUpload={checkFile}
+                            onChange={handleFileChange}
                             fileList={fileList}
                             onSuccessUpload={handleImageChange}
                             onPreview={handlePreview}

--- a/src/features/AdminPage/CategoriesPage/CategoriesPage/CategoryAdminModal.styles.scss
+++ b/src/features/AdminPage/CategoriesPage/CategoriesPage/CategoryAdminModal.styles.scss
@@ -1,0 +1,5 @@
+.categoryModal {
+    .ant-upload-list-item {
+        filter: grayscale(100%);
+    }
+}

--- a/src/features/AdminPage/NewStreetcode/InterestingFactsBlock/FactsAdminModal/InterestingFactsAdminModal.component.tsx
+++ b/src/features/AdminPage/NewStreetcode/InterestingFactsBlock/FactsAdminModal/InterestingFactsAdminModal.component.tsx
@@ -9,6 +9,7 @@ import CancelBtn from '@assets/images/utils/Cancel_btn.svg';
 import useMobx from '@stores/root-store';
 
 import imageValidator from '@/app/common/components/modals/validators/imageValidator';
+import { SUPPORTED_IMAGE_FILE_TYPES } from '@constants/file-types.constants';
 
 import {
     Button, Form, Input, message, Modal, Popover, UploadFile,
@@ -42,12 +43,9 @@ const InterestingFactsAdminModal = ({ fact, open, setModalOpen, onChange }: Prop
     const [previewOpen, setPreviewOpen] = useState<boolean>(false);
     const [hasUploadedPhoto, setHasUploadedPhoto] = useState<boolean>(false);
 
-    const checkFile = (file: UploadFile) => {
-        return (file.type === 'image/jpeg') || (file.type === 'image/webp')
-            || (file.type === 'image/png') || (file.type === 'image/jpg');
-    }
+    const checkFile = (file: UploadFile) => file.type && SUPPORTED_IMAGE_FILE_TYPES.includes(file.type);
 
-    const handleChange = async (param: UploadChangeParam<UploadFile<any>>) => {
+    const handleFileChange = async (param: UploadChangeParam<UploadFile<unknown>>) => {
         if (checkFile(param.file)) {
             setFileList(param.fileList);
         }
@@ -221,7 +219,7 @@ const InterestingFactsAdminModal = ({ fact, open, setModalOpen, onChange }: Prop
                                 maxCount={1}
                                 fileList={fileList}
                                 beforeUpload={checkFile}
-                                onChange={handleChange}
+                                onChange={handleFileChange}
                                 onSuccessUpload={(image: Image | Audio) => {
                                     imageId.current = image.id;
                                     setHasUploadedPhoto(true);

--- a/src/features/AdminPage/NewStreetcode/InterestingFactsBlock/FactsAdminModal/InterestingFactsAdminModal.component.tsx
+++ b/src/features/AdminPage/NewStreetcode/InterestingFactsBlock/FactsAdminModal/InterestingFactsAdminModal.component.tsx
@@ -8,6 +8,8 @@ import getNewMinNegativeId from '@app/common/utils/newIdForStore';
 import CancelBtn from '@assets/images/utils/Cancel_btn.svg';
 import useMobx from '@stores/root-store';
 
+import imageValidator from '@/app/common/components/modals/validators/imageValidator';
+
 import {
     Button, Form, Input, message, Modal, Popover, UploadFile,
 } from 'antd';
@@ -40,13 +42,13 @@ const InterestingFactsAdminModal = ({ fact, open, setModalOpen, onChange }: Prop
     const [previewOpen, setPreviewOpen] = useState<boolean>(false);
     const [hasUploadedPhoto, setHasUploadedPhoto] = useState<boolean>(false);
 
-    const checkFile = async (file: UploadFile) => {
+    const checkFile = (file: UploadFile) => {
         return (file.type === 'image/jpeg') || (file.type === 'image/webp')
             || (file.type === 'image/png') || (file.type === 'image/jpg');
     }
 
     const handleChange = async (param: UploadChangeParam<UploadFile<any>>) => {
-        if (await checkFile(param.file)) {
+        if (checkFile(param.file)) {
             setFileList(param.fileList);
         }
     }
@@ -208,27 +210,7 @@ const InterestingFactsAdminModal = ({ fact, open, setModalOpen, onChange }: Prop
                             name="image"
                             rules={[
                                 { required: true, message: 'Завантажте фото, будь ласка' },
-                                {
-                                    validator: (_, file) => {
-                                        if (file) {
-                                            console.log(file);
-                                            let name = '';
-                                            if (file.file) {
-                                                name = file.file.name.toLowerCase();
-                                            } else if (file.name) {
-                                                name = file.name.toLowerCase();
-                                            }
-                                            if (name.endsWith('.jpeg') || name.endsWith('.png') || name.endsWith('.webp')
-                                                || name.endsWith('.jpg') || name === '') {
-                                                console.log(name)
-                                                return Promise.resolve();
-                                            }
-                                            // eslint-disable-next-line max-len
-                                            return Promise.reject(Error('Тільки файли з розширенням webp, jpeg, png, jpg дозволені!'));
-                                        }
-                                        return Promise.reject();
-                                    },
-                                },
+                                { validator: imageValidator },
                             ]}
                         >
                             <FileUploader

--- a/src/features/AdminPage/NewStreetcode/InterestingFactsBlock/FactsAdminModal/InterestingFactsAdminModal.component.tsx
+++ b/src/features/AdminPage/NewStreetcode/InterestingFactsBlock/FactsAdminModal/InterestingFactsAdminModal.component.tsx
@@ -8,8 +8,7 @@ import getNewMinNegativeId from '@app/common/utils/newIdForStore';
 import CancelBtn from '@assets/images/utils/Cancel_btn.svg';
 import useMobx from '@stores/root-store';
 
-import imageValidator from '@/app/common/components/modals/validators/imageValidator';
-import { SUPPORTED_IMAGE_FILE_TYPES } from '@constants/file-types.constants';
+import imageValidator, { checkImageFileType } from '@/app/common/components/modals/validators/imageValidator';
 
 import {
     Button, Form, Input, message, Modal, Popover, UploadFile,
@@ -43,7 +42,7 @@ const InterestingFactsAdminModal = ({ fact, open, setModalOpen, onChange }: Prop
     const [previewOpen, setPreviewOpen] = useState<boolean>(false);
     const [hasUploadedPhoto, setHasUploadedPhoto] = useState<boolean>(false);
 
-    const checkFile = (file: UploadFile) => file.type && SUPPORTED_IMAGE_FILE_TYPES.includes(file.type);
+    const checkFile = (file: UploadFile) => checkImageFileType(file.type);
 
     const handleFileChange = async (param: UploadChangeParam<UploadFile<unknown>>) => {
         if (checkFile(param.file)) {

--- a/src/features/AdminPage/NewStreetcode/MainBlock/FileInputsPart.component.tsx
+++ b/src/features/AdminPage/NewStreetcode/MainBlock/FileInputsPart.component.tsx
@@ -20,8 +20,7 @@ import base64ToUrl from '@/app/common/utils/base64ToUrl.utility';
 import Audio, { AudioUpdate } from '@/models/media/audio.model';
 
 import PreviewFileModal from './PreviewFileModal/PreviewFileModal.component';
-import imageValidator from '@/app/common/components/modals/validators/imageValidator';
-import { SUPPORTED_IMAGE_FILE_TYPES } from '@constants/file-types.constants';
+import imageValidator, { checkImageFileType } from '@/app/common/components/modals/validators/imageValidator';
 
 const convertFileToUploadFile = (file: Image | Audio) => {
     const newFileList: UploadFile = {
@@ -196,7 +195,7 @@ const FileInputsPart = ({ form, onChange }: FileInputsPartProps) => {
         }
     }, []);
 
-    const checkFile = (file: UploadFile) => file.type && SUPPORTED_IMAGE_FILE_TYPES.includes(file.type);
+    const checkFile = (file: UploadFile) => checkImageFileType(file.type);
 
     const handleAnimationChange = (param: UploadChangeParam<UploadFile<unknown>>) => {
         if (checkFile(param.file)) {

--- a/src/features/AdminPage/NewStreetcode/MainBlock/FileInputsPart.component.tsx
+++ b/src/features/AdminPage/NewStreetcode/MainBlock/FileInputsPart.component.tsx
@@ -205,13 +205,13 @@ const FileInputsPart = ({ form, onChange }: FileInputsPartProps) => {
 
     const handleBlackAndWhiteChange = (param: UploadChangeParam<UploadFile<unknown>>) => {
         if (checkFile(param.file)) {
-            setAnimation(param.fileList);
+            setBlackAndWhite(param.fileList);
         }
     };
 
     const handleRelatedFigureChange = (param: UploadChangeParam<UploadFile<unknown>>) => {
         if (checkFile(param.file)) {
-            setAnimation(param.fileList);
+            setRelatedFigure(param.fileList);
         }
     };
 

--- a/src/features/AdminPage/NewStreetcode/MainBlock/FileInputsPart.component.tsx
+++ b/src/features/AdminPage/NewStreetcode/MainBlock/FileInputsPart.component.tsx
@@ -10,6 +10,7 @@ import { ModelState } from '@models/enums/model-state';
 import Image, { ImageAssigment, ImageCreateUpdate } from '@models/media/image.model';
 
 import { FormInstance, Modal, UploadFile } from 'antd';
+import { UploadChangeParam } from 'antd/es/upload';
 import FormItem from 'antd/es/form/FormItem';
 
 import AudiosApi from '@/app/api/media/audios.api';
@@ -20,6 +21,7 @@ import Audio, { AudioUpdate } from '@/models/media/audio.model';
 
 import PreviewFileModal from './PreviewFileModal/PreviewFileModal.component';
 import imageValidator from '@/app/common/components/modals/validators/imageValidator';
+import { SUPPORTED_IMAGE_FILE_TYPES } from '@constants/file-types.constants';
 
 const convertFileToUploadFile = (file: Image | Audio) => {
     const newFileList: UploadFile = {
@@ -194,11 +196,25 @@ const FileInputsPart = ({ form, onChange }: FileInputsPartProps) => {
         }
     }, []);
 
-    const checkFile = (file: UploadFile) =>
-        (file.type === 'image/jpeg')
-        || (file.type === 'image/webp')
-        || (file.type === 'image/png')
-        || (file.type === 'image/jpg');
+    const checkFile = (file: UploadFile) => file.type && SUPPORTED_IMAGE_FILE_TYPES.includes(file.type);
+
+    const handleAnimationChange = (param: UploadChangeParam<UploadFile<unknown>>) => {
+        if (checkFile(param.file)) {
+            setAnimation(param.fileList);
+        }
+    };
+
+    const handleBlackAndWhiteChange = (param: UploadChangeParam<UploadFile<unknown>>) => {
+        if (checkFile(param.file)) {
+            setAnimation(param.fileList);
+        }
+    };
+
+    const handleRelatedFigureChange = (param: UploadChangeParam<UploadFile<unknown>>) => {
+        if (checkFile(param.file)) {
+            setAnimation(param.fileList);
+        }
+    };
 
     return (
         <div>
@@ -215,11 +231,7 @@ const FileInputsPart = ({ form, onChange }: FileInputsPartProps) => {
                         maxCount={1}
                         fileList={animation}
                         beforeUpload={checkFile}
-                        onChange={(param) => {
-                            if (checkFile(param.file)) {
-                                setAnimation(param.fileList);
-                            }
-                        }}
+                        onChange={handleAnimationChange}
                         onPreview={handlePreview}
                         uploadTo="image"
                         onSuccessUpload={(file: Image | Audio) => {
@@ -253,11 +265,7 @@ const FileInputsPart = ({ form, onChange }: FileInputsPartProps) => {
                         maxCount={1}
                         fileList={blackAndWhite}
                         beforeUpload={checkFile}
-                        onChange={(param) => {
-                            if (checkFile(param.file)) {
-                                setBlackAndWhite(param.fileList);
-                            }
-                        }}
+                        onChange={handleBlackAndWhiteChange}
                         onPreview={handlePreview}
                         uploadTo="image"
                         onSuccessUpload={(file: Image | Audio) => {
@@ -287,11 +295,7 @@ const FileInputsPart = ({ form, onChange }: FileInputsPartProps) => {
                         onPreview={handlePreview}
                         uploadTo="image"
                         beforeUpload={checkFile}
-                        onChange={(param) => {
-                            if (checkFile(param.file)) {
-                                setRelatedFigure(param.fileList);
-                            }
-                        }}
+                        onChange={handleRelatedFigureChange}
                         onSuccessUpload={(file: Image | Audio) => {
                             handleFileUpload(file.id, 'relatedFigureId', 'imagesUpdate');
                             setRelatedFigure([convertFileToUploadFile(file as Image)]);

--- a/src/features/AdminPage/NewStreetcode/MainBlock/FileInputsPart.component.tsx
+++ b/src/features/AdminPage/NewStreetcode/MainBlock/FileInputsPart.component.tsx
@@ -19,6 +19,7 @@ import base64ToUrl from '@/app/common/utils/base64ToUrl.utility';
 import Audio, { AudioUpdate } from '@/models/media/audio.model';
 
 import PreviewFileModal from './PreviewFileModal/PreviewFileModal.component';
+import imageValidator from '@/app/common/components/modals/validators/imageValidator';
 
 const convertFileToUploadFile = (file: Image | Audio) => {
     const newFileList: UploadFile = {
@@ -193,34 +194,19 @@ const FileInputsPart = ({ form, onChange }: FileInputsPartProps) => {
         }
     }, []);
 
+    const checkFile = (file: UploadFile) =>
+        (file.type === 'image/jpeg')
+        || (file.type === 'image/webp')
+        || (file.type === 'image/png')
+        || (file.type === 'image/jpg');
+
     return (
         <div>
             <div className="photo-uploader-container scrollable-container">
                 <FormItem
                     name="animations"
                     label="Кольорове"
-                    rules={[
-                        {
-                            validator: (_, file) => {
-                                if (file) {
-                                    let name = '';
-                                    if (file.file) {
-                                        name = file.file.name.toLowerCase();
-                                    } else if (file.name) {
-                                        name = file.name.toLowerCase();
-                                    }
-                                    if (name.endsWith('.jpeg') || name.endsWith('.png') || name.endsWith('.webp')
-                                        || name.endsWith('.jpg') || name === '') {
-                                        return Promise.resolve();
-                                    }
-                                    return Promise.reject(
-                                        Error('Дозволені тільки файли з розширенням .jpeg, .jpg, .png та .webp'),
-                                    );
-                                }
-                                return Promise.resolve();
-                            },
-                        },
-                    ]}
+                    rules={[{ validator: imageValidator }]}
                 >
                     <FileUploader
                         accept=".jpeg,.png,.jpg,.webp"
@@ -228,13 +214,11 @@ const FileInputsPart = ({ form, onChange }: FileInputsPartProps) => {
                         multiple={false}
                         maxCount={1}
                         fileList={animation}
-                        beforeUpload={(file) => {
-                            const isValid = (file.type === 'image/jpeg') || (file.type === 'image/webp')
-                                || (file.type === 'image/png') || (file.type === 'image/jpg');
-                            if (!isValid) {
-                                return Promise.reject();
+                        beforeUpload={checkFile}
+                        onChange={(param) => {
+                            if (checkFile(param.file)) {
+                                setAnimation(param.fileList);
                             }
-                            return Promise.resolve();
                         }}
                         onPreview={handlePreview}
                         uploadTo="image"
@@ -254,29 +238,12 @@ const FileInputsPart = ({ form, onChange }: FileInputsPartProps) => {
                 <FormItem
                     name="pictureBlackWhite"
                     label="Чорнобіле"
-                    rules={[{
-                        required: true,
-                        message: 'Додайте зображення',
-                    },
-                    {
-                        validator: (_, file) => {
-                            if (file) {
-                                let name = '';
-                                if (file.file) {
-                                    name = file.file.name.toLowerCase();
-                                } else if (file.name) {
-                                    name = file.name.toLowerCase();
-                                }
-                                if (name.endsWith('.jpeg') || name.endsWith('.png') || name.endsWith('.webp')
-                                    || name.endsWith('.jpg') || name === '') {
-                                    return Promise.resolve();
-                                }
-                                // eslint-disable-next-line max-len
-                                return Promise.reject(Error('Тільки файли з розширенням webp, jpeg, png, jpg дозволені!'));
-                            }
-                            return Promise.reject();
+                    rules={[
+                        {
+                            required: true,
+                            message: 'Додайте зображення',
                         },
-                    },
+                        { validator: imageValidator },
                     ]}
                 >
                     <FileUploader
@@ -285,16 +252,14 @@ const FileInputsPart = ({ form, onChange }: FileInputsPartProps) => {
                         listType="picture-card"
                         maxCount={1}
                         fileList={blackAndWhite}
+                        beforeUpload={checkFile}
+                        onChange={(param) => {
+                            if (checkFile(param.file)) {
+                                setBlackAndWhite(param.fileList);
+                            }
+                        }}
                         onPreview={handlePreview}
                         uploadTo="image"
-                        beforeUpload={(file) => {
-                            const isValid = (file.type === 'image/jpeg') || (file.type === 'image/webp')
-                                || (file.type === 'image/png') || (file.type === 'image/jpg');
-                            if (!isValid) {
-                                return Promise.reject();
-                            }
-                            return Promise.resolve();
-                        }}
                         onSuccessUpload={(file: Image | Audio) => {
                             handleFileUpload(file.id, 'blackAndWhiteId', 'imagesUpdate');
                             setBlackAndWhite([convertFileToUploadFile(file as Image)]);
@@ -311,28 +276,7 @@ const FileInputsPart = ({ form, onChange }: FileInputsPartProps) => {
                 <FormItem
                     name="pictureRelations"
                     label="Для зв'язків"
-                    rules={[
-                        {
-                            validator: (_, file) => {
-                                if (file) {
-                                    let name = '';
-                                    if (file.file) {
-                                        name = file.file.name.toLowerCase();
-                                    } else if (file.name) {
-                                        name = file.name.toLowerCase();
-                                    }
-                                    if (name.endsWith('.jpeg') || name.endsWith('.png') || name.endsWith('.webp')
-                                        || name.endsWith('.jpg') || name === '') {
-                                        setVisibleErrorRelatedFigure(false);
-                                        return Promise.resolve();
-                                    }
-                                    setVisibleErrorRelatedFigure(true);
-                                    return Promise.resolve();
-                                }
-                                return Promise.resolve();
-                            },
-                        },
-                    ]}
+                    rules={[{ validator: imageValidator }]}
                 >
                     <FileUploader
                         multiple={false}
@@ -342,14 +286,11 @@ const FileInputsPart = ({ form, onChange }: FileInputsPartProps) => {
                         fileList={relatedFigure}
                         onPreview={handlePreview}
                         uploadTo="image"
-                        beforeUpload={(file) => {
-                            const isValid = (file.type === 'image/jpeg')
-                                || (file.type === 'image/png')
-                                || (file.type === 'image/jpg' || (file.type === 'image/webp'));
-                            if (!isValid) {
-                                return Promise.reject();
+                        beforeUpload={checkFile}
+                        onChange={(param) => {
+                            if (checkFile(param.file)) {
+                                setRelatedFigure(param.fileList);
                             }
-                            return Promise.resolve();
                         }}
                         onSuccessUpload={(file: Image | Audio) => {
                             handleFileUpload(file.id, 'relatedFigureId', 'imagesUpdate');

--- a/src/features/AdminPage/NewStreetcode/StreetcodeArtsBlock/components/Download.component.tsx
+++ b/src/features/AdminPage/NewStreetcode/StreetcodeArtsBlock/components/Download.component.tsx
@@ -21,7 +21,7 @@ import Image from '@/models/media/image.model';
 import Audio from '@/models/media/audio.model';
 
 import PreviewImageModal from './PreviewImageModal/PreviewImageModal.component';
-import { SUPPORTED_IMAGE_FILE_TYPES } from '@constants/file-types.constants';
+import { checkImageFileType } from '@/app/common/components/modals/validators/imageValidator';
 
 const DownloadBlock = () => {
     const { id } = useParams<any>();
@@ -143,8 +143,8 @@ const DownloadBlock = () => {
         setVisibleDeleteButton(false);
     };
 
-    const handleBeforeUpload = async (file: UploadFile) => {
-        const isImage = file.type && SUPPORTED_IMAGE_FILE_TYPES.includes(file.type);
+    const handleBeforeUpload = (file: UploadFile) => {
+        const isImage = checkImageFileType(file.type);
         if (!isImage) {
             setVisibleError(true);
         }

--- a/src/features/AdminPage/NewStreetcode/StreetcodeArtsBlock/components/Download.component.tsx
+++ b/src/features/AdminPage/NewStreetcode/StreetcodeArtsBlock/components/Download.component.tsx
@@ -21,7 +21,7 @@ import Image from '@/models/media/image.model';
 import Audio from '@/models/media/audio.model';
 
 import PreviewImageModal from './PreviewImageModal/PreviewImageModal.component';
-import ArtGalleryTemplateStore from '@/app/stores/art-gallery-template-store';
+import { SUPPORTED_IMAGE_FILE_TYPES } from '@constants/file-types.constants';
 
 const DownloadBlock = () => {
     const { id } = useParams<any>();
@@ -144,18 +144,14 @@ const DownloadBlock = () => {
     };
 
     const handleBeforeUpload = async (file: UploadFile) => {
-        const isImage = (
-            (file.type === 'image/jpeg') || 
-            (file.type === 'image/webp') || 
-            (file.type === 'image/png') || 
-            (file.type === 'image/jpg')
-        )
+        const isImage = file.type && SUPPORTED_IMAGE_FILE_TYPES.includes(file.type);
         if (!isImage) {
             setVisibleError(true);
         }
-        
+
         return isImage || Upload.LIST_IGNORE;
-    }
+    };
+
     return (
         <div className="art-gallery-download">
             <FileUploader

--- a/src/features/AdminPage/PartnersPage/PartnerModal/PartnerModal.component.tsx
+++ b/src/features/AdminPage/PartnersPage/PartnerModal/PartnerModal.component.tsx
@@ -34,6 +34,7 @@ import { runInAction } from 'mobx';
 import POPOVER_CONTENT from '../../JobsPage/JobsModal/constants/popoverContent';
 import { UploadChangeParam } from 'antd/es/upload';
 import imageValidator from '@/app/common/components/modals/validators/imageValidator';
+import { SUPPORTED_IMAGE_FILE_TYPES } from '@constants/file-types.constants';
 
 const PartnerModal: React.FC< {
     partnerItem?: Partner;
@@ -306,13 +307,9 @@ const PartnerModal: React.FC< {
             }
         };
 
-        const checkFile = (file: UploadFile) =>
-            (file.type === 'image/jpeg')
-            || (file.type === 'image/webp')
-            || (file.type === 'image/png')
-            || (file.type === 'image/jpg');
+        const checkFile = (file: UploadFile) => file.type && SUPPORTED_IMAGE_FILE_TYPES.includes(file.type);
 
-        const handleFileChange = (param: UploadChangeParam<UploadFile<any>>) => {
+        const handleFileChange = (param: UploadChangeParam<UploadFile<unknown>>) => {
             if (checkFile(param.file)) {
                 setFileList(param.fileList);
             }

--- a/src/features/AdminPage/PartnersPage/PartnerModal/PartnerModal.component.tsx
+++ b/src/features/AdminPage/PartnersPage/PartnerModal/PartnerModal.component.tsx
@@ -32,13 +32,15 @@ import { StreetcodeShort } from '@/models/streetcode/streetcode-types.model';
 import ImageStore from '@/app/stores/image-store';
 import { runInAction } from 'mobx';
 import POPOVER_CONTENT from '../../JobsPage/JobsModal/constants/popoverContent';
+import { UploadChangeParam } from 'antd/es/upload';
+import imageValidator from '@/app/common/components/modals/validators/imageValidator';
 
 const PartnerModal: React.FC< {
-  partnerItem?: Partner;
-  open: boolean;
-  isStreetcodeVisible?: boolean;
-  setIsModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
-  afterSubmit?: (partner: Partner) => void;
+    partnerItem?: Partner;
+    open: boolean;
+    isStreetcodeVisible?: boolean;
+    setIsModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+    afterSubmit?: (partner: Partner) => void;
 }> = observer(
     ({
         partnerItem,
@@ -304,6 +306,18 @@ const PartnerModal: React.FC< {
             }
         };
 
+        const checkFile = (file: UploadFile) =>
+            (file.type === 'image/jpeg')
+            || (file.type === 'image/webp')
+            || (file.type === 'image/png')
+            || (file.type === 'image/jpg');
+
+        const handleFileChange = (param: UploadChangeParam<UploadFile<any>>) => {
+            if (checkFile(param.file)) {
+                setFileList(param.fileList);
+            }
+        };
+
         return (
             <Modal
                 open={open}
@@ -380,7 +394,7 @@ const PartnerModal: React.FC< {
                         </Form.Item>
                         {urlTitleEnabled === '' && urlTitleValue && (
                             <p className="error-text">
-                Введіть правильне посилання для збереження назви посилання.
+                                Введіть правильне посилання для збереження назви посилання.
                             </p>
                         )}
 
@@ -391,19 +405,15 @@ const PartnerModal: React.FC< {
                         <Form.Item
                             name="logo"
                             label="Лого"
-                            valuePropName="fileList"
-                            getValueFromEvent={(e: any) => {
-                                if (Array.isArray(e)) {
-                                    return e;
-                                }
-                                return e?.fileList;
-                            }}
-                            rules={[{ required: true, message: 'Завантажте лого' }]}
+                            rules={[
+                                {
+                                    required: true,
+                                    message: 'Завантажте лого',
+                                },
+                                { validator: imageValidator },
+                            ]}
                         >
                             <FileUploader
-                                onChange={(param) => {
-                                    setFileList(param.fileList);
-                                }}
                                 fileList={fileList}
                                 className="logo-uploader"
                                 multiple={false}
@@ -411,6 +421,8 @@ const PartnerModal: React.FC< {
                                 listType="picture-card"
                                 maxCount={1}
                                 onPreview={handlePreview}
+                                beforeUpload={checkFile}
+                                onChange={handleFileChange}
                                 onRemove={() => {
                                     imageId.current = 0;
                                 }}
@@ -468,7 +480,7 @@ const PartnerModal: React.FC< {
                         onClick={handleShowSecondForm}
                         className="add-social-media-button"
                     >
-            Додати соціальну мережу
+                        Додати соціальну мережу
                     </Button>
                 )}
                 <Form
@@ -480,7 +492,7 @@ const PartnerModal: React.FC< {
                         <div>
                             <div className="button-container">
                                 <Button onClick={handleHideSecondForm} className="close-button">
-                  Закрити
+                                    Закрити
                                 </Button>
                             </div>
                             <div className="link-container">
@@ -536,7 +548,7 @@ const PartnerModal: React.FC< {
                         <Popover content="Завершіть додавання соціальної мережі" trigger="hover">
                             <span>
                                 <Button disabled className="streetcode-custom-button save">
-                  Зберегти
+                                    Зберегти
                                 </Button>
                             </span>
                         </Popover>
@@ -546,7 +558,7 @@ const PartnerModal: React.FC< {
                             className="streetcode-custom-button save"
                             onClick={handleOk}
                         >
-              Зберегти
+                            Зберегти
                         </Button>
                     )}
                 </div>

--- a/src/features/AdminPage/PartnersPage/PartnerModal/PartnerModal.component.tsx
+++ b/src/features/AdminPage/PartnersPage/PartnerModal/PartnerModal.component.tsx
@@ -33,8 +33,7 @@ import ImageStore from '@/app/stores/image-store';
 import { runInAction } from 'mobx';
 import POPOVER_CONTENT from '../../JobsPage/JobsModal/constants/popoverContent';
 import { UploadChangeParam } from 'antd/es/upload';
-import imageValidator from '@/app/common/components/modals/validators/imageValidator';
-import { SUPPORTED_IMAGE_FILE_TYPES } from '@constants/file-types.constants';
+import imageValidator, { checkImageFileType } from '@/app/common/components/modals/validators/imageValidator';
 
 const PartnerModal: React.FC< {
     partnerItem?: Partner;
@@ -307,7 +306,7 @@ const PartnerModal: React.FC< {
             }
         };
 
-        const checkFile = (file: UploadFile) => file.type && SUPPORTED_IMAGE_FILE_TYPES.includes(file.type);
+        const checkFile = (file: UploadFile) => checkImageFileType(file.type);
 
         const handleFileChange = (param: UploadChangeParam<UploadFile<unknown>>) => {
             if (checkFile(param.file)) {

--- a/src/features/AdminPage/TeamPage/TeamModal/TeamModal.component.tsx
+++ b/src/features/AdminPage/TeamPage/TeamModal/TeamModal.component.tsx
@@ -32,6 +32,7 @@ import Audio from '@/models/media/audio.model';
 import POPOVER_CONTENT from '../../JobsPage/JobsModal/constants/popoverContent';
 import { UploadChangeParam } from 'antd/es/upload';
 import imageValidator from '@/app/common/components/modals/validators/imageValidator';
+import { SUPPORTED_IMAGE_FILE_TYPES } from '@constants/file-types.constants';
 
 const TeamModal: React.FC<{
     teamMember?: TeamMember, open: boolean,
@@ -158,11 +159,11 @@ const TeamModal: React.FC<{
         setCustomWarningVisible(false);
         setInvalidWarningVisible(false);
 
-        if(!url){
+        if (!url) {
             return;
         }
 
-        if(!URL.canParse(url)){
+        if (!URL.canParse(url)) {
             setInvalidWarningVisible(true);
             return;
         }
@@ -172,18 +173,16 @@ const TeamModal: React.FC<{
         } else {
             const newId = getNewId(teamSourceLinks);
             const isLogoTypePresent = teamSourceLinks.some(obj => obj.logoType === Number(LogoType[logotype]));
-            
-            if(isLogoTypePresent){
+
+            if (isLogoTypePresent) {
                 setExistWarningVisible(true);
-            }
-            else {
+            } else {
                 setTeamSourceLinks([...teamSourceLinks, {
                     id: newId,
                     logoType: Number(LogoType[logotype]),
                     targetUrl: url,
                 }]);
             }
-            
         }
     };
 
@@ -250,13 +249,9 @@ const TeamModal: React.FC<{
         setIsMain(e.target.checked);
     };
 
-    const checkFile = (file: UploadFile) =>
-        (file.type === 'image/jpeg')
-        || (file.type === 'image/webp')
-        || (file.type === 'image/png')
-        || (file.type === 'image/jpg');
+    const checkFile = (file: UploadFile) => file.type && SUPPORTED_IMAGE_FILE_TYPES.includes(file.type);
 
-    const handleFileChange = (param: UploadChangeParam<UploadFile<any>>) => {
+    const handleFileChange = (param: UploadChangeParam<UploadFile<unknown>>) => {
         if (checkFile(param.file)) {
             setFileList(param.fileList);
         }

--- a/src/features/AdminPage/TeamPage/TeamModal/TeamModal.component.tsx
+++ b/src/features/AdminPage/TeamPage/TeamModal/TeamModal.component.tsx
@@ -31,8 +31,7 @@ import Image from '@/models/media/image.model';
 import Audio from '@/models/media/audio.model';
 import POPOVER_CONTENT from '../../JobsPage/JobsModal/constants/popoverContent';
 import { UploadChangeParam } from 'antd/es/upload';
-import imageValidator from '@/app/common/components/modals/validators/imageValidator';
-import { SUPPORTED_IMAGE_FILE_TYPES } from '@constants/file-types.constants';
+import imageValidator, { checkImageFileType } from '@/app/common/components/modals/validators/imageValidator';
 
 const TeamModal: React.FC<{
     teamMember?: TeamMember, open: boolean,
@@ -249,7 +248,7 @@ const TeamModal: React.FC<{
         setIsMain(e.target.checked);
     };
 
-    const checkFile = (file: UploadFile) => file.type && SUPPORTED_IMAGE_FILE_TYPES.includes(file.type);
+    const checkFile = (file: UploadFile) => checkImageFileType(file.type);
 
     const handleFileChange = (param: UploadChangeParam<UploadFile<unknown>>) => {
         if (checkFile(param.file)) {

--- a/src/features/AdminPage/TeamPage/TeamModal/TeamModal.component.tsx
+++ b/src/features/AdminPage/TeamPage/TeamModal/TeamModal.component.tsx
@@ -30,6 +30,8 @@ import TeamLink from '@/features/AdminPage/TeamPage/TeamLink.component';
 import Image from '@/models/media/image.model';
 import Audio from '@/models/media/audio.model';
 import POPOVER_CONTENT from '../../JobsPage/JobsModal/constants/popoverContent';
+import { UploadChangeParam } from 'antd/es/upload';
+import imageValidator from '@/app/common/components/modals/validators/imageValidator';
 
 const TeamModal: React.FC<{
     teamMember?: TeamMember, open: boolean,
@@ -248,6 +250,18 @@ const TeamModal: React.FC<{
         setIsMain(e.target.checked);
     };
 
+    const checkFile = (file: UploadFile) =>
+        (file.type === 'image/jpeg')
+        || (file.type === 'image/webp')
+        || (file.type === 'image/png')
+        || (file.type === 'image/jpg');
+
+    const handleFileChange = (param: UploadChangeParam<UploadFile<any>>) => {
+        if (checkFile(param.file)) {
+            setFileList(param.fileList);
+        }
+    };
+
     return (
         <Modal
             open={open}
@@ -313,36 +327,29 @@ const TeamModal: React.FC<{
                     <Form.Item
                         name="image"
                         label="Фото"
-                        valuePropName="fileList"
-                        getValueFromEvent={(e: any) => {
-                            if (Array.isArray(e)) {
-                                return e;
-                            }
-                            return e?.fileList;
-                        }}
                         rules={[
                             {
                                 required: true,
                                 message: 'Будь ласка, завантажте фото',
                             },
+                            { validator: imageValidator },
                         ]}
                     >
                         <FileUploader
-                            onChange={(param) => {
-                                setFileList(param.fileList);
-                            }}
                             fileList={fileList}
                             multiple={false}
                             accept=".jpeg,.png,.jpg,.webp"
                             listType="picture-card"
                             maxCount={1}
+                            beforeUpload={checkFile}
+                            onChange={handleFileChange}
                             onPreview={(e) => {
                                 setFilePreview(e); setPreviewOpen(true);
                             }}
                             onRemove={removeImage}
                             uploadTo="image"
                             onSuccessUpload={(file: Image | Audio) => {
-                                let image: Image = file as Image;
+                                const image: Image = file as Image;
                                 imageId.current = image.id;
                             }}
                             defaultFileList={getImageAsFileInArray()}


### PR DESCRIPTION
* Ticket ita-social-projects/StreetCode#1724

## Summary of issue

When attempting to upload a non-accepted photo format (e.g., a "pdf" file) to the "Картинка" field, the system does not display an error message.
The "Зберегти" button remains activated, allowing the user to proceed despite the invalid file format.

## Summary of change

When attempting to upload a non-accepted photo format error message appears and "Зберегти" button becomes disabled where needed

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
