### PR TITLE
feature/issue-1743

### DIFF
--- a/src/app/common/components/CopyWithCopyright.component.tsx
+++ b/src/app/common/components/CopyWithCopyright.component.tsx
@@ -3,13 +3,14 @@ import React, { useRef } from 'react';
 import FRONTEND_ROUTES from '../constants/frontend-routes.constants';
 
 interface Props {
-  children: React.ReactNode;
-  copyrightText: string;
+    children: React.ReactNode;
+    copyrightText: string;
+    className?: string;
 }
 
 const MIN_LENGTH = 20;
 
-const CopyWithCopyright = ({ children, copyrightText }: Props) => {
+const CopyWithCopyright = ({ children, copyrightText, className }: Props) => {
     const textRef = useRef<HTMLDivElement>(null);
 
     const handleCopy = (event: React.ClipboardEvent<HTMLDivElement>) => {
@@ -28,7 +29,7 @@ const CopyWithCopyright = ({ children, copyrightText }: Props) => {
     };
 
     return (
-        <div ref={textRef} onCopy={handleCopy}>
+        <div ref={textRef} onCopy={handleCopy} className={className}>
             {children}
         </div>
     );

--- a/src/app/layout/app/App.component.tsx
+++ b/src/app/layout/app/App.component.tsx
@@ -34,7 +34,7 @@ const App = () => {
             <HeaderBlock />
             <div className="mainWrapper">
                 <div className={`${isPageDimmed ? 'dimmed' : ''}`} />
-                <CopyWithCopyright copyrightText={CopyrightText}>
+                <CopyWithCopyright copyrightText={CopyrightText} className='mainBlockWrapper'>
                     {(pathname !== FRONTEND_ROUTES.BASE) && (
                         <Outlet />
                     )}


### PR DESCRIPTION
* Ticket ita-social-projects/StreetCode#1743

## Summary of issue

Instead of stretching out the background only reaches half of the screen while loading Streetcodes.

## Summary of change

Changed styles for CopyWithCopyright to stretch out the page component to page height.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
