### PR TITLE
feature/issue-900

### DIFF
--- a/src/features/StreetcodePage/QRBlock/QRMobile/QRMobile.styles.scss
+++ b/src/features/StreetcodePage/QRBlock/QRMobile/QRMobile.styles.scss
@@ -32,8 +32,10 @@ $loadImg: '@assets/images/qr-block/must_be_gif.webp';
     p{
         padding-bottom: pxToRem(15px);
     }
-    button{
+    a{
         margin-top: pxToRem(15px);
+    }
+    button{
         width: pxToRem(340px);
         height: pxToRem(46px);
         border-radius: 10px;


### PR DESCRIPTION
* Ticket ita-social-projects/StreetCode#900

## Summary of issue

The area over the 'Перейти в Instagram' button is clickable.

## Summary of change

Removed margin from button so it doesn`t stretch anchor element outside the button itself.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
