### PR TITLE
Card rounding on Streetcode page removed on width 1024 and lower

### DIFF
--- a/src/features/StreetcodePage/MainBlock/StreetcodeCard/StreetcodeCard.styles.scss
+++ b/src/features/StreetcodePage/MainBlock/StreetcodeCard/StreetcodeCard.styles.scss
@@ -188,6 +188,7 @@
     }
     .card {
       @include mut.sized(100%, 495px);
+      @include mut.full-rounded(0);
       background-color: rgba(0, 0, 0, 0) !important;
       box-shadow: none;
       .rightSider{


### PR DESCRIPTION
* Ticket ita-social-projects/StreetCode#904

## Summary of issue

The 'Прослухати текст'/'Аудіо на підході' button is cut off at the bottom right

## Summary of change

Card rounding on Streetcode page removed on width 1024 and lower

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
