### PR TITLE
feature/issue-1679

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,6 @@ pipeline {
     }
     options {
             skipDefaultCheckout true
-            disableConcurrentBuilds()
     }
     stages {
          stage('Checkout') {


### PR DESCRIPTION
* Ticket ita-social-projects/StreetCode#1679

## Summary of issue

The disableConcurrentBuilds() option currently prevents multiple builds from running at the same time, which can cause delays in the pipeline execution.

## Summary of change

Removed disableConcurrentBuilds() option.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
