### PR TITLE
feature/issue-903

### DIFF
--- a/src/features/SlickSlider/InterestingFactSliderSlickSlider.component.tsx
+++ b/src/features/SlickSlider/InterestingFactSliderSlickSlider.component.tsx
@@ -13,11 +13,12 @@ const GenericSlider: FC<SliderProps> = ({
     children,
     onClick,
     swipeOnClick = true,
+    initialSlide = 0,
     ...sliderProps
 }) => {
     const { modalStore: { setModal } } = useModalContext();
     const sliderRef = useRef<Slider>(null);
-    const [currentIndex, setCurrentIndex] = useState(0);
+    const [currentIndex, setCurrentIndex] = useState(initialSlide);
     const [lastClick, setLastClick] = useState(Date.now());
 
     const isOnRightEdge = (
@@ -64,7 +65,7 @@ const GenericSlider: FC<SliderProps> = ({
             <Slider
                 ref={sliderRef}
                 {...sliderProps}
-                initialSlide={sliderProps.initialSlide}
+                initialSlide={initialSlide}
                 beforeChange={(currentSlide, nextSlide) => setCurrentIndex(nextSlide)} // for handle dots click
                 className={!sliderProps.infinite ? 'nonInfiniteSlider' : ''}
             >

--- a/src/features/SlickSlider/index.ts
+++ b/src/features/SlickSlider/index.ts
@@ -7,6 +7,7 @@ export default interface SliderProps extends SliderWithoutChildren {
     swipeOnClick?: boolean;
     children: JSX.Element[];
     secondPreset?: boolean;
+    initialSlide?: number;
 }
 
 export const defaultSliderProps: SliderWithoutChildren = {


### PR DESCRIPTION
* Ticket ita-social-projects/StreetCode#903

## Summary of issue

After the user is directed to the block of wow-facts and clicks on card, the fact moves instead of opening.

## Summary of change

Properly set initial slide for SlickSlider.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
