### PR TITLE
Image validation fixed

### DIFF
--- a/src/app/common/components/modals/validators/imageValidator.tsx
+++ b/src/app/common/components/modals/validators/imageValidator.tsx
@@ -12,14 +12,14 @@ const imageValidator = (_: RuleObject, file: any): Promise<void> => {
 
         const allowedExtensions = ['.jpeg', '.png', '.webp', '.jpg'];
 
-        if (allowedExtensions.some((ext) => name.endsWith(ext))) {
+        if (name === '' || allowedExtensions.some((ext) => name.endsWith(ext))) {
             return Promise.resolve();
         }
 
         return Promise.reject(new Error('Тільки файли з розширенням webp, jpeg, png, jpg дозволені!'));
     }
 
-    return Promise.reject();
+    return Promise.resolve();
 };
 
 export const checkImageFileType = (type: string | undefined) => type && SUPPORTED_IMAGE_FILE_TYPES.includes(type);


### PR DESCRIPTION
* Ticket ita-social-projects/StreetCode#1785

## Summary of issue

Cannot create streetcode although all mandatory fields are filled
Only after clicking on trash bin icon on the uploaded image the error message 'Тільки файли з розширенням webp, jpeg, png, jpg дозволені!' appears.

## Summary of change

Error message works correctly
You can create streetcode when all mandatory fields are filled

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
