### PR TITLE
Partners that are visible everywhere disabled in partners list while editing streetcode

### DIFF
--- a/src/app/stores/partners-store.ts
+++ b/src/app/stores/partners-store.ts
@@ -20,22 +20,23 @@ export default class PartnersStore {
         this.PartnerMap.set(partner.id, partner);
     };
 
+    get getPartnerArray() {
+        return Array.from(this.PartnerMap.values());
+    }
+
+    public static getAllPartners = async () => {
+        try {
+            return await partnersApi.getAll();
+        } catch (error: unknown) {}
+        return [];
+    };
+
     public static async getAllPartnerShort():Promise<PartnerShort[]> {
         try {
             return await partnersApi.getAllShort();
         } catch (error: unknown) {}
         return [];
     }
-
-    get getPartnerArray() {
-        return Array.from(this.PartnerMap.values());
-    }
-
-    public getAll = async () => {
-        try {
-            this.setInternalMap(await partnersApi.getAll());
-        } catch (error: unknown) {}
-    };
 
     public fetchPartnersByStreetcodeId = async (streetcodeId: number) => {
         try {

--- a/src/features/AdminPage/NewStreetcode/MainNewStreetcode.component.tsx
+++ b/src/features/AdminPage/NewStreetcode/MainNewStreetcode.component.tsx
@@ -276,7 +276,7 @@ const NewStreetcode = () => {
                             }));
 
                         setPartners(persistedPartners);
-                    }
+                    },
                 );
                 SubtitlesApi.getSubtitlesByStreetcodeId(parseId)
                     .then((resultSubtitle) => {

--- a/src/features/AdminPage/NewStreetcode/PartnerBlock/PartnerBlockAdmin.components.tsx
+++ b/src/features/AdminPage/NewStreetcode/PartnerBlock/PartnerBlockAdmin.components.tsx
@@ -14,31 +14,30 @@ interface Props {
 }
 
 const PartnerBlockAdmin = ({ partners, setPartners, onChange }: Props) => {
-    const [allPartnersShort, setAllPartnerShort] = useState<PartnerShort[]>([]);
+    const [allPartners, setAllPartners] = useState<Partner[]>([]);
     const [modalAddOpened, setModalAddOpened] = useState<boolean>(false);
 
     useEffect(() => {
         Promise.all([
-            PartnersStore.getAllPartnerShort()
-                .then((parts) => setAllPartnerShort(parts)),
+            PartnersStore.getAllPartners()
+                .then((parts) => setAllPartners(parts)),
         ]);
     }, []);
 
     const afterSubmit = (partner: Partner) => {
-        console.log(partner);
-        const existingPartner = partners.find((p) => p.id === partner.id);
-        const existingPartnerShort = allPartnersShort.find((p) => p.id === partner.id);
-        if (!existingPartner) {
+        const existingPartnerCreateUpdate = partners.find((p) => p.id === partner.id);
+        const existingPartner = allPartners.find((p) => p.id === partner.id);
+        if (!existingPartnerCreateUpdate) {
             setPartners([...partners, {
                 id: partner.id,
                 title: partner.title,
                 modelState: ModelState.Created,
             }]);
         }
-        if (!existingPartnerShort) {
-            setAllPartnerShort([...allPartnersShort, { id: partner.id, title: partner.title }]);
+        if (!existingPartner) {
+            setAllPartners([...allPartners, partner]);
         }
-    }
+    };
 
     const onPartnerSelect = (value: number) => {
         const existingPartner = partners.find((p) => p.id === value);
@@ -48,7 +47,7 @@ const PartnerBlockAdmin = ({ partners, setPartners, onChange }: Props) => {
             existingPartner.modelState = ModelState.Updated;
             setPartners([...updatedPartners, existingPartner]);
         } else {
-            const partner = allPartnersShort.find((c) => c.id === value) as PartnerCreateUpdateShort;
+            const partner = allPartners.find((c) => c.id === value) as PartnerCreateUpdateShort;
             partner.modelState = ModelState.Created;
             setPartners([...updatedPartners, partner]);
         }
@@ -70,7 +69,7 @@ const PartnerBlockAdmin = ({ partners, setPartners, onChange }: Props) => {
     const alphabeticalSorting = (partnersItems: PartnerShort[]) => partnersItems.slice()
         .sort((a, b) => a.title.localeCompare(b.title));
 
-    const sortedPartners = alphabeticalSorting(allPartnersShort);
+    const sortedPartners = alphabeticalSorting(allPartners);
 
     return (
         <div className="adminContainer-block">
@@ -83,7 +82,15 @@ const PartnerBlockAdmin = ({ partners, setPartners, onChange }: Props) => {
                         .map((x) => x.id)}
                     onDeselect={onPartnerDeselect}
                 >
-                    {sortedPartners.map((s) => <Select.Option key={`${s.id}`} value={s.id}>{s.title}</Select.Option>)}
+                    {sortedPartners.map((s) => (
+                        <Select.Option
+                            key={`${s.id}`}
+                            value={s.id}
+                            disabled={allPartners.find((p) => p.id === s.id)?.isVisibleEverywhere}
+                        >
+                            {s.title}
+                        </Select.Option>
+                    ))}
                 </Select>
 
                 <Button

--- a/src/features/AdminPage/NewStreetcode/PartnerBlock/PartnerBlockAdmin.components.tsx
+++ b/src/features/AdminPage/NewStreetcode/PartnerBlock/PartnerBlockAdmin.components.tsx
@@ -10,7 +10,7 @@ import Partner, { PartnerCreateUpdateShort, PartnerShort } from '@/models/partne
 interface Props {
     partners: PartnerCreateUpdateShort[],
     setPartners: React.Dispatch<React.SetStateAction<PartnerCreateUpdateShort[]>>,
-    onChange: (field: string, value: any) => void,
+    onChange: (field: string, value: unknown) => void,
 }
 
 const PartnerBlockAdmin = ({ partners, setPartners, onChange }: Props) => {


### PR DESCRIPTION
* Ticket ita-social-projects/StreetCode#1777

## Summary of issue

We have 2 partners that set all Streetcodes by default, these are “Український інститут національної пам'яті” and “Railsware”. When we go to the admin page and edit any Streetcode, we don’t have partner labels by default in the “Партнери” section, which can confuse the user of the admin page.
Moreover, in the drop-down list of the same section they are not marked as selected.

## Summary of change

Partners that are visible everywhere disabled in partners list while editing streetcode

![image_2024-09-29_19-47-47](https://github.com/user-attachments/assets/9213e0ba-e6d2-4305-b9f1-4d352f6ede0e)

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
