### PR TITLE
Admin login page made a little bit prettier

### DIFF
--- a/src/features/AdminPage/Login/AdminLogin.component.tsx
+++ b/src/features/AdminPage/Login/AdminLogin.component.tsx
@@ -63,17 +63,17 @@ const AdminLogin: React.FC = () => {
             <Form.Item name="password" label="Пароль" rules={[{ required: true, message: 'Введіть пароль' }]}>
                 <Input.Password maxLength={30} />
             </Form.Item>
-            <div className="captchaBlock">
+            <div className="captchaBlock center">
                 <ReCAPTCHA
                     className="required-captcha"
                     sitekey={siteKey}
                     onChange={handleVerify}
                     onExpired={handleExpiration}
                     ref={recaptchaRef}
-                    hl='uk'
+                    hl="uk"
                 />
             </div>
-            <Form.Item>
+            <Form.Item className="center">
                 <Button htmlType="submit" className="streetcode-custom-button">
                     Увійти
                 </Button>

--- a/src/features/AdminPage/Login/AdminLogin.style.scss
+++ b/src/features/AdminPage/Login/AdminLogin.style.scss
@@ -1,11 +1,23 @@
-
 @use "@sass/mixins/_utils.mixins.scss" as mut;
 @use "@sass/variables/_variables.fonts.scss" as ft;
 @use "@sass/variables/_variables.colors.scss" as c;
 @use "@sass/_utils.functions.scss" as f;
+
 .admin-login-form{
     padding-top: 100px;
     @include mut.sized(400px,200px);
     margin: auto;
 
+    .ant-form-item-label {
+        flex: 0 0 80px;
+    }
+
+    .captchaBlock {
+        margin-bottom: f.pxToRem(24px);
+    }
+
+    .center {
+        display: flex;
+        justify-content: center;
+    }
 }


### PR DESCRIPTION
* Ticket ita-social-projects/StreetCode#1443

## Summary of issue

Under the 'Логін' field, the 'Пароль' field is shifted to the right.

## Summary of change

- The 'Пароль' field is located exactly below the 'Логін' field.
- Captcha centered and bottom margin added
- Login button centered 

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
