### PR TITLE
Solved problem with disappeared 'Заголовок' field in Streetcode edit mode

### DIFF
--- a/src/features/AdminPage/NewStreetcode/MainNewStreetcode.component.tsx
+++ b/src/features/AdminPage/NewStreetcode/MainNewStreetcode.component.tsx
@@ -677,6 +677,7 @@ const NewStreetcode = () => {
                             <TextBlock
                                 parseId={parseId}
                                 inputInfo={inputInfo}
+                                form={form}
                                 setInputInfo={setInputInfo}
                                 video={video}
                                 setVideo={setVideo}

--- a/src/features/AdminPage/NewStreetcode/TextBlock/TextBlock.component.tsx
+++ b/src/features/AdminPage/NewStreetcode/TextBlock/TextBlock.component.tsx
@@ -1,7 +1,9 @@
 /* eslint-disable no-restricted-imports */
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import TextsApi from '@api/streetcode/text-content/texts.api';
 import { useAsync } from '@hooks/stateful/useAsync.hook';
+
+import { FormInstance } from 'antd';
 
 import Video from '@/models/media/video.model';
 import { Text } from '@/models/streetcode/text-contents.model';
@@ -10,6 +12,7 @@ import TextForm from './TextForm/TextForm.component';
 
 interface Props {
     inputInfo: Partial<Text> | undefined;
+    form: FormInstance<unknown>,
     setInputInfo: React.Dispatch<React.SetStateAction<Partial<Text> | undefined>>;
     video: Video | undefined;
     setVideo: React.Dispatch<Video | undefined>;
@@ -18,7 +21,7 @@ interface Props {
 }
 
 const TextBlock = React.memo(({
-    inputInfo, setInputInfo, video, setVideo, onChange, parseId,
+    inputInfo, form, setInputInfo, video, setVideo, onChange, parseId,
 }: Props) => {
     const [inputInfoAsync, setInputInfoAsync] = useState<Partial<Text>| undefined>();
     const [canLoad, setCanLoad] = useState<boolean>(parseId === null);
@@ -34,6 +37,7 @@ const TextBlock = React.memo(({
     return (
         canLoad ? (
             <TextForm
+                form={form}
                 inputInfo={inputInfo}
                 setInputInfo={setInputInfo}
                 video={video}

--- a/src/features/AdminPage/NewStreetcode/TextBlock/TextForm/TextForm.component.tsx
+++ b/src/features/AdminPage/NewStreetcode/TextBlock/TextForm/TextForm.component.tsx
@@ -1,6 +1,8 @@
 import './TextForm.styles.scss';
 
-import { Form, Input } from 'antd';
+import { useEffect } from 'react';
+
+import { Form, FormInstance, Input } from 'antd';
 
 import QUILL_TEXTS_LENGTH from
     '@/features/AdminPage/NewStreetcode/TextBlock/TextLengthConstants/textMaxLength.constant';
@@ -14,9 +16,10 @@ import TextPreview from './TextPreview/TextPreview.component';
 
 const isQuillEmpty = (text: string | undefined) => {
     return !text || text.replace(/<(.|\n)*?>/g, '').trim().length === 0;
-}
+};
 
 interface Props {
+    form: FormInstance<unknown>,
     inputInfo: Partial<Text> | undefined;
     setInputInfo: React.Dispatch<React.SetStateAction<Partial<Text> | undefined>>;
     video: Video | undefined;
@@ -24,7 +27,7 @@ interface Props {
     onChange: (fieldName: string, value: any) => void;
 }
 const TextForm = ({
-    inputInfo, setInputInfo, video, setVideo, onChange,
+    form, inputInfo, setInputInfo, video, setVideo, onChange,
 }: Props) => {
     const maxTitleLength = 50;
     const handleChangeTitle = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -35,6 +38,13 @@ const TextForm = ({
         }));
         onChange('title', value);
     };
+
+    useEffect(() => {
+        form.setFieldsValue({
+            title: inputInfo?.title,
+        });
+    }, [inputInfo, form]);
+
     return (
         <Form.Item className="textForm">
             <Form.Item
@@ -50,7 +60,6 @@ const TextForm = ({
                     },
                 },
                 ]}
-                initialValue={inputInfo?.title}
             >
                 <Input
                     showCount


### PR DESCRIPTION
## Ticket
- [Main GitHub ticket](https://github.com/ita-social-projects/StreetCode/issues/1780)

## Code reviewers
- [ ] @sashapanasiuk5 
- [ ] @darkravchuk 
- [ ] @ulyasaur  

## Summary of issue
- 'Заголовок' text disappears when admin edits Streetcode.

## Summary of change
- The 'Заголовок' field was not set properly in the code and it was decided to set it by passing the form and calling a special method.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
