### PR TITLE
Added unique title validation for News entities

### DIFF
--- a/src/features/AdminPage/CategoriesPage/CategoriesPage/CategoryAdminModal.component.spec.tsx
+++ b/src/features/AdminPage/CategoriesPage/CategoriesPage/CategoryAdminModal.component.spec.tsx
@@ -34,7 +34,6 @@ jest.mock('@app/api/sources/sources.api', () => ({
     default: {
         create: jest.fn(),
         update: jest.fn(),
-        getAllCategories: () => [],
     },
 }));
 
@@ -178,10 +177,10 @@ describe('CategoryAdminModal', () => {
         });
 
         await waitFor(() => {
+            expect(saveButton).toBeDisabled();
             expect(message.success).toHaveBeenCalled();
             expect(SourcesApi.update).toHaveBeenCalled();
             expect(SourcesApi.create).not.toHaveBeenCalled();
-            expect(saveButton).toBeDisabled();
         });
     });
 

--- a/src/features/AdminPage/CategoriesPage/CategoriesPage/CategoryAdminModal.component.spec.tsx
+++ b/src/features/AdminPage/CategoriesPage/CategoriesPage/CategoryAdminModal.component.spec.tsx
@@ -96,7 +96,7 @@ describe('CategoryAdminModal', () => {
     it('calls setIsModalOpen with false when the cancel button is clicked', async () => {
         const setIsModalOpen = jest.fn();
         act(() => {
-            render(<CategoryAdminModal {...defaultProps} isModalVisible={true} setIsModalOpen={setIsModalOpen} />);
+            render(<CategoryAdminModal {...defaultProps} setIsModalOpen={setIsModalOpen} />);
         });
 
         act(() => {
@@ -127,7 +127,30 @@ describe('CategoryAdminModal', () => {
         const saveButton = screen.getByRole('button', { name: /Зберегти/i });
         const uploader = screen.getByTestId('fileuploader');
 
+        await waitFor(() => {
+            userEvent.type(screen.getByRole('textbox', { name: /Назва/i }), 'New category');
+            userEvent.upload(uploader, new File(['(⌐□_□)'], 'new-image.jpg', { type: 'image/jpg' }));
+        });
+
+        await waitFor(() => userEvent.click(saveButton));
+
+        await waitFor(() => {
+            expect(SourcesApi.create).toHaveBeenCalled();
+            expect(isNewCategory).toHaveBeenCalledWith(true);
+            expect(message.success).toHaveBeenCalled();
+        });
+    });
+
+    it('should disable save button after creating', async () => {
+        const isNewCategory = jest.fn();
         act(() => {
+            render(<CategoryAdminModal {...defaultProps} isNewCategory={isNewCategory} />);
+        });
+
+        const saveButton = screen.getByRole('button', { name: /Зберегти/i });
+        const uploader = screen.getByTestId('fileuploader');
+
+        await waitFor(() => {
             userEvent.type(screen.getByRole('textbox', { name: /Назва/i }), 'New category');
             userEvent.upload(uploader, new File(['(⌐□_□)'], 'new-image.jpg', { type: 'image/jpg' }));
         });
@@ -136,16 +159,10 @@ describe('CategoryAdminModal', () => {
             expect(saveButton).not.toBeDisabled();
         });
 
-        act(() => {
-            userEvent.click(saveButton);
-        });
+        await waitFor(() => userEvent.click(saveButton));
 
         await waitFor(() => {
             expect(saveButton).toBeDisabled();
-            expect(message.success).toHaveBeenCalled();
-            expect(SourcesApi.create).toHaveBeenCalled();
-            expect(isNewCategory).toHaveBeenCalledWith(true);
-            expect(SourcesApi.update).not.toHaveBeenCalled();
         });
     });
 
@@ -163,24 +180,49 @@ describe('CategoryAdminModal', () => {
         const saveButton = screen.getByRole('button', { name: /Зберегти/i });
         const fileuploader = screen.getByTestId('fileuploader');
 
-        act(() => {
+        await waitFor(() => {
             userEvent.clear(nameInput);
             userEvent.type(nameInput, 'New category');
             userEvent.upload(fileuploader, new File(['(⌐□_□)'], 'new-image.jpg', { type: 'image/jpg' }));
         });
+
+        await waitFor(() => userEvent.click(saveButton));
+
+        await waitFor(() => {
+            expect(SourcesApi.update).toHaveBeenCalled();
+            expect(SourcesApi.create).not.toHaveBeenCalled();
+            expect(message.success).toHaveBeenCalled();
+        });
+    });
+
+    it('should disable save button after updating', async () => {
+        const initialData = {
+            id: 1,
+            title: 'Category',
+            imageId: 1,
+        };
+        act(() => {
+            render(<CategoryAdminModal {...defaultProps} initialData={initialData} />);
+        });
+
+        const nameInput = screen.getByRole('textbox', { name: /Назва/i });
+        const saveButton = screen.getByRole('button', { name: /Зберегти/i });
+        const fileuploader = screen.getByTestId('fileuploader');
+
+        await waitFor(() => {
+            userEvent.clear(nameInput);
+            userEvent.type(nameInput, 'New category');
+            userEvent.upload(fileuploader, new File(['(⌐□_□)'], 'new-image.jpg', { type: 'image/jpg' }));
+        });
+
         await waitFor(() => {
             expect(saveButton).not.toBeDisabled();
         });
 
-        act(() => {
-            userEvent.click(saveButton);
-        });
+        await waitFor(() => userEvent.click(saveButton));
 
         await waitFor(() => {
             expect(saveButton).toBeDisabled();
-            expect(message.success).toHaveBeenCalled();
-            expect(SourcesApi.update).toHaveBeenCalled();
-            expect(SourcesApi.create).not.toHaveBeenCalled();
         });
     });
 
@@ -200,9 +242,7 @@ describe('CategoryAdminModal', () => {
             expect(saveButton).not.toBeDisabled();
         });
 
-        act(() => {
-            userEvent.click(saveButton);
-        });
+        await waitFor(() => userEvent.click(saveButton));
 
         await waitFor(() => {
             expect(message.error).toHaveBeenCalled();

--- a/src/features/AdminPage/CategoriesPage/CategoriesPage/CategoryAdminModal.component.tsx
+++ b/src/features/AdminPage/CategoriesPage/CategoriesPage/CategoryAdminModal.component.tsx
@@ -78,6 +78,7 @@ const SourceModal: React.FC<SourceModalProps> = ({
             ImagesApi.getById(initialData.imageId)
                 .then((img) => {
                     initialData.image = img;
+                    setImage(img);
                     form.setFieldsValue({
                         image: createFileListData(img),
                     });

--- a/src/features/AdminPage/NewsPage/NewsModal/NewsModal.component.tsx
+++ b/src/features/AdminPage/NewsPage/NewsModal/NewsModal.component.tsx
@@ -39,6 +39,7 @@ import Audio from '@/models/media/audio.model';
 import Image from '@/models/media/image.model';
 import News from '@/models/news/news.model';
 import POPOVER_CONTENT from '../../JobsPage/JobsModal/constants/popoverContent';
+import uniquenessValidator from '@/app/common/utils/uniquenessValidator';
 
 const NewsModal: React.FC<{
     newsItem?: News;
@@ -94,14 +95,12 @@ const NewsModal: React.FC<{
         return newsList.every((news: News) => news.url !== url);
     };
 
-    const checkUniqueTitle = async (title: string): Promise<boolean> => {
-        const newsList = newsStore.NewsArray;
-        if(newsItem) {
-            const filteredNewsList = newsList.filter((news: News) => news.id !== newsItem?.id);
-            return filteredNewsList.every((news: News) => news.title !== title);
-        }
-        return newsList.every((news: News) => news.title !== title);
-    }
+    const validateTitle = uniquenessValidator(
+        () => newsStore.NewsArray.map((news: News) => news.title.trim()),
+        () => newsItem?.title?.trim(),
+        'Заголовок вже існує',
+    );
+    
 
     useEffect(() => {
         editorRef.current?.editor?.setText('');
@@ -205,7 +204,6 @@ const NewsModal: React.FC<{
             image: undefined,
             creationDate: dayjs(formValues.creationDate),
         };
-        console.log(newsItem);
         newsStore.NewsArray.map((t) => t).forEach((t) => {
             if (formValues.title == t.title || imageId.current == t.imageId) newsItem = t;
         });
@@ -280,14 +278,8 @@ const NewsModal: React.FC<{
                             rules={[
                                 { required: true, message: 'Введіть заголовок' },
                                 {
-                                    validator: async (_, value) => {
-                                        const isUnique = await checkUniqueTitle(value);
-                                        if (isUnique) {
-                                            return Promise.resolve();
-                                        }
-                                        return Promise.reject(new Error('Заголовок вже існує'));
-                                    }
-                                }                          
+                                    validator: validateTitle,
+                                }                       
                             ]}
                         >
                             <Input maxLength={100} showCount onChange={handleInputChange} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -6542,6 +6542,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
+fsevents@^2.3.2, fsevents@~2.3.2:
+  version "2.3.3"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
+
 function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz"


### PR DESCRIPTION
### Summary of Issue
The main issue involves adding validation to ensure that News entities have unique titles within the system. The current implementation lacks a check, which allows duplicate news entries with the same title, leading to potential conflicts and confusion when managing content.

### Summary of Change
- Implemented a validation check that prevents duplicate titles when creating or updating a News entity.
- Modified the form to validate title uniqueness before submission.
- Adjusted the error handling logic to notify the user if a duplicate title is detected.