### PR TITLE
Fixed an issue with text overlapping the frame in the timeline

### DIFF
--- a/src/features/StreetcodePage/TimelineBlock/TimelineBlock.styles.scss
+++ b/src/features/StreetcodePage/TimelineBlock/TimelineBlock.styles.scss
@@ -33,7 +33,7 @@ $timelineSquareImg: "@assets/images/timeline/Square.webp";
     }
 
     .slick-list {
-      margin:f.pxToRem(0) !important;
+      margin: f.pxToRem(0) !important;
     }
 
   .slick-track {
@@ -53,13 +53,13 @@ $timelineSquareImg: "@assets/images/timeline/Square.webp";
 
     .slick-slide {
       border-radius: 40px;
-      border-width:f.pxToRem(15px) f.pxToRem(15px);
+      border-width: f.pxToRem(15px) f.pxToRem(15px);
       border-style: solid ;
       border-color: c.$timeline-reel-color;
       @include mut.bg-image($timelineSquareImg);
       
 
-      background-size:f.pxToRem(605px) f.pxToRem(365px);
+      background-size: f.pxToRem(605px) f.pxToRem(365px);
       background-position: center;   
 
       &:nth-child(2n + 1) {
@@ -72,7 +72,7 @@ $timelineSquareImg: "@assets/images/timeline/Square.webp";
     
     .slick-current {
       border-radius: 40px;
-      box-shadow: inset  0px 0px 0px 6px c.$pure-white-color;
+      box-shadow: inset  0 0 0 6px c.$pure-white-color;
     }
   }
 }
@@ -107,12 +107,12 @@ $timelineSquareImg: "@assets/images/timeline/Square.webp";
         }
         .slick-slide {
           border-radius: 20px;
-          border-width:f.pxToRem(7px) f.pxToRem(7px);
-          background-size:f.pxToRem(295px) f.pxToRem(185px);
+          border-width: f.pxToRem(7px) f.pxToRem(7px);
+          background-size: f.pxToRem(295px) f.pxToRem(211px);
           background-position: center;  
         }
         .slick-current {
-          box-shadow: inset  0px 0px 0px 3px c.$pure-white-color;
+          box-shadow: inset  0 0 0 3px c.$pure-white-color;
         }
       }
     }

--- a/src/features/StreetcodePage/TimelineBlock/TimelineItem/TimelineItem.styles.scss
+++ b/src/features/StreetcodePage/TimelineBlock/TimelineItem/TimelineItem.styles.scss
@@ -62,7 +62,7 @@
 
 @media screen and (max-width: 1024px) {
   .timelineItem{
-    @include mut.sized(299px, 190px);
+    @include mut.sized(299px, 208px);
     border-radius: 15px;
     .timelineItemContent{
       padding: f.pxToRem(13px);


### PR DESCRIPTION
## Ticket
- [Main GitHub ticket](https://github.com/ita-social-projects/StreetCode/issues/861)

## Code reviewers
- [ ] @sashapanasiuk5 
- [ ] @darkravchuk 
- [ ] @ulyasaur  

## Summary of issue
- The text of the card spills over into the white frame.

## Summary of change
- Now the text no longer overlaps the frame.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
