### PR TITLE
Feature/issue 1927

### DIFF
--- a/src/app/common/components/FileUploader/FileUploader.component.tsx
+++ b/src/app/common/components/FileUploader/FileUploader.component.tsx
@@ -68,6 +68,15 @@ const FileUploader:React.FC<Props> = ({
         }
     };
 
+    const checkFileType = (file: UploadFile) => {
+        const parts = file.name.split('.');
+        const extension = parts.length > 1 ? `.${parts.pop()}` : '';
+        if (uploadProps.accept?.split(',').every((x) => x !== extension)) {
+            return false;
+        }
+        return true;
+    };
+
     const onFileUpload = (uploadType:'image' | 'audio', uplFile:UploadFile, url: string)
     :Promise< ImageNew | Audio> => {
         if (uploadType === 'audio') {
@@ -131,6 +140,7 @@ const FileUploader:React.FC<Props> = ({
     return (
         <Upload
             {...uploadProps}
+            beforeUpload={checkFileType}
             customRequest={customRequest}
             onChange={onUploadChange}
             data-testid="fileuploader"

--- a/src/features/AdminPage/NewsPage/NewsModal/NewsModal.component.tsx
+++ b/src/features/AdminPage/NewsPage/NewsModal/NewsModal.component.tsx
@@ -352,7 +352,8 @@ const NewsModal: React.FC<{
                                 message: 'Додайте зображення',
                             },
                             {
-                                validator: (_, file) => {
+                                validator: (_, fileList) => {
+                                    const file = fileList[0]
                                     if (file) {
                                         let name = '';
                                         if (file.file) {


### PR DESCRIPTION
dev

* [Github ticket](https://github.com/ita-social-projects/StreetCode/issues/1927)

## Summary of issue

An uninformative error message is displayed when attempting to upload a file of an unsupported format

## Summary of change

Form validation is fixed and added file type check before uploading file
