### PR TITLE
Feature/issue 1917

### DIFF
--- a/src/features/StreetcodeCatalogPage/StreetcodeCatalog.component.tsx
+++ b/src/features/StreetcodeCatalogPage/StreetcodeCatalog.component.tsx
@@ -26,7 +26,7 @@ const StreetcodeCatalog = () => {
     }, [screen]);
 
     useAsync(async () => {
-        const count = await StreetcodesApi.getCount();
+        const count = await StreetcodesApi.getCount(true);
 
         if (count === getCatalogStreetcodesArray.length) {
             return;


### PR DESCRIPTION
* [Github ticket](https://github.com/ita-social-projects/StreetCode/issues/1971)



## Summary of issue

Duplicated street codes were loaded because the count included all street codes in the database (archived, drafted, and published), while only street codes with a "published" status were being fetched. This caused an endless loop of API calls.

## Summary of change

Updated the API call for counting street codes to include the onlyPublished parameter set to true, ensuring that only "published" street codes are counted. This resolved the duplication issue by aligning the count logic with the fetching logic.
