### PR TITLE
Feature/issue 1814

### DIFF
--- a/src/features/StreetcodeCatalogPage/StreetcodeCatalog.component.tsx
+++ b/src/features/StreetcodeCatalogPage/StreetcodeCatalog.component.tsx
@@ -63,15 +63,15 @@ const StreetcodeCatalog = () => {
                         )
                     }
                 </div>
+                {
+                    loading && (moreThenEight)
+                    && (
+                        <div className="loadingWrapper">
+                            <div id="loadingGif" />
+                        </div>
+                    )
+                }
             </div>
-            {
-                loading && (moreThenEight)
-                && (
-                    <div className="loadingWrapper">
-                        <div id="loadingGif" />
-                    </div>
-                )
-            }
         </div>
     );
 };


### PR DESCRIPTION
* [Github ticket](https://github.com/ita-social-projects/StreetCode/issues/1814)


## Summary of issue

While loading new street codes on the catalog page, the loader GIF appeared below the footer

## Summary of change

Repositioned the loader GIF to ensure it is displayed in the correct location on the catalog page
