### PR TITLE
fix: add default sort option for fetching streetcodes

### DIFF
--- a/src/features/AdminPage/StreetcodesTable/StreetcodesTable.component.tsx
+++ b/src/features/AdminPage/StreetcodesTable/StreetcodesTable.component.tsx
@@ -15,6 +15,7 @@ import {
 } from 'antd';
 import Table from 'antd/es/table/Table';
 
+import sortOptions from '@features/AdminPage/StreetcodesTable/constants/sortOptions';
 import StreetcodesApi from '@/app/api/streetcode/streetcodes.api';
 import FRONTEND_ROUTES from '@/app/common/constants/frontend-routes.constants';
 import { useModalContext } from '@/app/stores/root-store';
@@ -50,7 +51,7 @@ const StreetcodesTable = () => {
         Page: pageRequest,
         Amount: amountRequest,
         Title: null,
-        Sort: null,
+        Sort: sortOptions.UpdatedAtDesc,
         Filter: null,
     };
 
@@ -68,7 +69,7 @@ const StreetcodesTable = () => {
             Page: page,
             Amount: amountRequest,
             Title: titleRequest === '' ? null : titleRequest,
-            Sort: null,
+            Sort: requestDefault.Sort,
             Filter: filter,
         });
     };

--- a/src/features/AdminPage/StreetcodesTable/constants/sortOptions.ts
+++ b/src/features/AdminPage/StreetcodesTable/constants/sortOptions.ts
@@ -1,0 +1,5 @@
+export enum SortOptions {
+    UpdatedAtAsc = 'UpdatedAt',
+    UpdatedAtDesc = '-UpdatedAt',
+}
+export default SortOptions;


### PR DESCRIPTION
dev
## JIRA

* [1914](https://github.com/ita-social-projects/StreetCode/issues/1914)

## Summary of issue

The sorting option was not specified as a default request parameter for fetching streetcodes but sorting was already implemented on the backend.

## Summary of change

Added sorting option by desc as a default query parameter for fetching streetcodes

