### PR TITLE
Feature/issue-1966

### DIFF
--- a/src/app/common/components/modals/RelatedFigures/RelatedFiguresModal.styles.scss
+++ b/src/app/common/components/modals/RelatedFigures/RelatedFiguresModal.styles.scss
@@ -79,6 +79,7 @@ $articlesImg: "@assets/images/sources/Articles.webp";
       flex-direction: column;
       overflow: visible;
       max-height: none;
+      height: min-content;
       @include mut.rem-padded($left: 8px, $top: 10.5px, $right: 4px, $bottom: 10.5px);
       background-color: c.$pure-white-color;
       border-radius: 20px;
@@ -106,18 +107,14 @@ $articlesImg: "@assets/images/sources/Articles.webp";
       &::after {
         content: "";
         position: absolute;
-        width: 0;
-        height: 0;
-        margin-left: -3em;
-        bottom: -25px;
-        left: 50%;
-        box-sizing: border-box;
-        z-index: -1 !important;
-        border: 1em solid black;
-        border-color: transparent transparent #FFFFFF #FFFFFF;
-        transform-origin: 0 0;
-        transform: rotate(-45deg);
-        box-shadow: -3px 3px 3px 0 rgba(0, 0, 0, 0.25);
+        top: 99%;
+        left: 30%;
+        transform: translateX(-30%);
+        width: 18px;
+        height: 14px;
+        background-color: #ffffff;
+        clip-path: polygon(0 0, 100% 0, 50% 100%);
+        z-index: -1;
       }
     }
   }

--- a/src/features/StreetcodePage/RelatedFiguresBlock/RelatedFigureItem/RelatedFigureItem.styles.scss
+++ b/src/features/StreetcodePage/RelatedFiguresBlock/RelatedFigureItem/RelatedFigureItem.styles.scss
@@ -7,18 +7,16 @@
 
 .relatedFigureSlide {
     @include mut.sized($width: 278px, $height: 380px);
-    @include mut.full-rounded($rad: 30px);
+    @include mut.full-rounded($rad: 40px);
     border: 3px solid c.$pure-white-color;
     box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
-    background-size: 285px;
+    background-size: contain;
     background-repeat: no-repeat;
     @include mut.positioned-as();
     @include mut.flexed($justify-content: center, $align-items: flex-end);
 
     @include vnd.vendored(transition, 'all .5s ease');
     cursor: pointer;
-
-    z-index: l.$modal;
 }
 
 .figureSlideText {
@@ -26,7 +24,6 @@
     @include mut.rounded($bottom-left: 30px, $bottom-right: 30px);
 
     background-color: c.$dark-red-color;
-    position: absolute;
     overflow: visible;
     @include vnd.vendored(transition, 'all .5s ease');
 
@@ -55,7 +52,7 @@
 
     &.mobile{
         @include mut.sized($width: 165px, $height: auto);
-        background-color: c.$pure-white-color;
+        background-color: c.$streetcode-background-color ;
 
         .heading {
             @include mut.sized($width: 100%);
@@ -133,6 +130,6 @@
         
         .sliderClass .slider-item-container {
             display: block !important;
-        }   
+        }
     }
 }

--- a/src/features/StreetcodePage/RelatedFiguresBlock/RelatedFigures.component.tsx
+++ b/src/features/StreetcodePage/RelatedFiguresBlock/RelatedFigures.component.tsx
@@ -110,8 +110,13 @@ const RelatedFiguresComponent = ({ setActiveTagId, setShowAllTags, streetcode }:
     };
 
     return getRelatedFiguresArray.length > 0 ? (
-        // eslint-disable-next-line max-len
-        <div className={`relatedFiguresWrapper container ${getRelatedFiguresArray.length > 4 ? 'bigWrapper' : 'smallWrapper'}`}>
+        <div
+            className={`relatedFiguresWrapper container ${
+                (!isDesktop && !isMobile)
+                    ? 'smallWrapper'
+                    : (getRelatedFiguresArray.length > 4 ? 'bigWrapper' : 'smallWrapper')
+            }`}
+        >
             <div className="relatedFiguresContainer">
                 <BlockHeading headingText="Зв'язки історії" />
                 <div className="relatedFiguresSliderContainer">

--- a/src/features/StreetcodePage/RelatedFiguresBlock/RelatedFigures.styles.scss
+++ b/src/features/StreetcodePage/RelatedFiguresBlock/RelatedFigures.styles.scss
@@ -16,6 +16,10 @@ $card-size: 380px;
             display: none;
         }
     }
+
+    @media screen and (max-width: 481px) {
+        height: f.pxToRem(250px) !important;
+    }
 }
 
 .relatedFiguresContainer {
@@ -93,9 +97,10 @@ $card-size: 380px;
     }
 }
 
-@media screen and (max-width: 767px) and (min-width: 481px) {
+@media screen and (max-width: 1024px) and (min-width: 481px) {
     .relatedFiguresWrapper {
-        @include mut.sized($height: 400px);
+        height: f.pxToRem(400px) !important;
+        margin-bottom: 0;
     }
 }
 

--- a/src/features/StreetcodePage/SourcesBlock/Sources.styles.scss
+++ b/src/features/StreetcodePage/SourcesBlock/Sources.styles.scss
@@ -8,6 +8,11 @@
 .sourcesWrapper {
     @include wr.main-page-block-wrapper();
     margin-top: 110px;
+
+    @media screen and (max-width: 1024px) and (min-width: 481px) {
+        margin-top: 0;
+    }
+
     .sourcesContainer {
         @include mut.sizedImportant(100%, 100%);
         @media screen and (max-width: 768px) {


### PR DESCRIPTION
dev
## JIRA

* [1966](https://github.com/ita-social-projects/StreetCode/issues/1966)


## Summary of issue

In the modal, the tag list (tooltip) did not wrap the image of the next element and was outside the modal. There was also a common issue seen on tablets and phones with large indents in this block.

## Summary of change

The styles for the tooltip have been changed, as well as the length of the wrappers for this block for each device.
