### PR TITLE
remove smooth scrolling when switching to another page

### DIFF
--- a/src/app/stores/streetcode-page-loader-store/streetcode-page-loader-store.spec.ts
+++ b/src/app/stores/streetcode-page-loader-store/streetcode-page-loader-store.spec.ts
@@ -8,9 +8,7 @@ beforeEach(() => {
 });
 
 describe('streetcode-page-loader-store', () => {
-    it('sets isPageLoaded to true when all blocks are loaded and transition is ended', () => {
-        store.endTransition();
-
+    it('sets isPageLoaded to true when all blocks are loaded', () => {
         const blockTypes = Object.values(StreetcodeBlock)
             .filter((value) => typeof value === 'number');
 
@@ -19,9 +17,7 @@ describe('streetcode-page-loader-store', () => {
         expect(store.isPageLoaded).toBe(true);
     });
 
-    it('sets isPageLoaded to false when not all blocks are loaded and transition is ended', () => {
-        store.endTransition();
-
+    it('sets isPageLoaded to false when not all blocks', () => {
         const blockTypes = Object.values(StreetcodeBlock)
             .filter((value) => typeof value === 'number').slice(2);
 
@@ -30,25 +26,13 @@ describe('streetcode-page-loader-store', () => {
         expect(store.isPageLoaded).toBe(false);
     });
 
-    it('sets isPageLoaded to false when all blocks but transition has not ended', () => {
-        const blockTypes = Object.values(StreetcodeBlock)
-            .filter((value) => typeof value === 'number');
-
-        blockTypes.forEach((block) => store.addBlockFetched(block as StreetcodeBlock));
-
-        expect(store.isPageLoaded).toBe(false);
-    });
-
     it('resets loader', () => {
-        store.endTransition();
         store.addBlockFetched(StreetcodeBlock.MainStreetcode);
 
         expect(store.getFetchedBlocks()[0]).toBe(StreetcodeBlock.MainStreetcode);
-        expect(store.isTransitionFinished).toBe(true);
 
         store.resetLoader();
 
         expect(store.getFetchedBlocks().length).toBe(0);
-        expect(store.isTransitionFinished).toBe(false);
     });
 });

--- a/src/app/stores/streetcode-page-loader-store/streetcode-page-loader-store.ts
+++ b/src/app/stores/streetcode-page-loader-store/streetcode-page-loader-store.ts
@@ -15,8 +15,6 @@ export default class StreetcodePageLoaderStore {
         [StreetcodeBlock.RelatedFigures, false],
     ]);
 
-    private isTransitionEnded = false;
-
     public constructor() {
         makeAutoObservable(this);
     }
@@ -30,23 +28,14 @@ export default class StreetcodePageLoaderStore {
             .filter((block) => this.isBlockFetchedMap.get(block));
     }
 
-    public endTransition() {
-        this.isTransitionEnded = true;
-    }
-
     public resetLoader() {
         Array.from(this.isBlockFetchedMap.keys()).forEach((key: StreetcodeBlock) => {
             this.isBlockFetchedMap.set(key, false);
         });
-        this.isTransitionEnded = false;
     }
 
     get isPageLoaded():boolean {
         const isAllblocksFetched = Array.from(this.isBlockFetchedMap.values()).every((x) => x);
-        return this.isTransitionEnded && isAllblocksFetched;
-    }
-
-    get isTransitionFinished(): boolean {
-        return this.isTransitionEnded;
+        return isAllblocksFetched;
     }
 }

--- a/src/features/StreetcodePage/Streetcode.component.tsx
+++ b/src/features/StreetcodePage/Streetcode.component.tsx
@@ -67,7 +67,6 @@ const StreetcodeContent = () => {
     };
 
     setTimeout(handleSurveyModalOpen, 500);
-    setTimeout(() => streecodePageLoaderContext.endTransition(), 1500);
 
     useAsync(async () => {
         const idParam = searchParams.get('qrid');

--- a/src/index.scss
+++ b/src/index.scss
@@ -23,10 +23,6 @@ body {
   overflow-x: hidden;
 }
 
-html {
-  scroll-behavior: smooth;
-}
-
 code {
   font-family: ft.$code-tag-font;
 }


### PR DESCRIPTION
* [Github ticket](https://github.com/ita-social-projects/StreetCode/issues/2018)
* [Previous PR related to this issue](https://github.com/ita-social-projects/StreetCode_Client/pull/1508)
## Summary of issue

Every page of site loads from the bottom of the pageToDo

## Summary of change

Smooth scrolling was disabled