### PR TITLE
Feature/issue 2014

### DIFF
--- a/src/app/common/components/FileUploader/FileUploader.component.tsx
+++ b/src/app/common/components/FileUploader/FileUploader.component.tsx
@@ -68,14 +68,6 @@ const FileUploader:React.FC<Props> = ({
         }
     };
 
-    const checkFileType = (file: UploadFile) => {
-        const parts = file.name.split('.');
-        const extension = parts.length > 1 ? `.${parts.pop()}` : '';
-        if (uploadProps.accept?.split(',').every((x) => x !== extension)) {
-            return false;
-        }
-        return true;
-    };
 
     const onFileUpload = (uploadType:'image' | 'audio', uplFile:UploadFile, url: string)
     :Promise< ImageNew | Audio> => {
@@ -140,7 +132,6 @@ const FileUploader:React.FC<Props> = ({
     return (
         <Upload
             {...uploadProps}
-            beforeUpload={checkFileType}
             customRequest={customRequest}
             onChange={onUploadChange}
             data-testid="fileuploader"

--- a/src/app/common/components/modals/validators/combinedImageValidator.tsx
+++ b/src/app/common/components/modals/validators/combinedImageValidator.tsx
@@ -1,0 +1,22 @@
+import fileSizeValidator from '@components/modals/validators/fileSizeValidator';
+import imageExtensionValidator from '@components/modals/validators/imageExtensionValidator';
+import MaxFileSizeMB from '@constants/enums/file-size.enum';
+
+import { RuleObject } from 'antd/es/form';
+import { UploadFile } from 'antd/es/upload';
+
+const combinedImageValidator = (isRequired: boolean) => async (_: RuleObject, file: UploadFile): Promise<void> => {
+    if (!file) {
+        return isRequired
+            ? Promise.reject()
+            : Promise.resolve();
+    }
+    try {
+        await imageExtensionValidator(_, file);
+        return await fileSizeValidator(MaxFileSizeMB.Image)(_, file);
+    } catch (error) {
+        return await Promise.reject(error);
+    }
+};
+
+export default combinedImageValidator;

--- a/src/app/common/components/modals/validators/fileSizeValidator.tsx
+++ b/src/app/common/components/modals/validators/fileSizeValidator.tsx
@@ -1,0 +1,29 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { RuleObject } from 'rc-field-form/lib/interface';
+
+import { MaxFileSizeMB } from '@/app/common/constants/enums/file-size.enum';
+
+const fileSizeValidator = (maxFileSize: MaxFileSizeMB) => (_: RuleObject, file: any): Promise<void> => {
+    if (file) {
+        const maxSizeInBytes = maxFileSize * 1024 * 1024;
+        let size = 0;
+
+        if (file.file) {
+            size = file.file.size;
+        } else if (file.size) {
+            size = file.size;
+        }
+
+        if (size <= maxSizeInBytes) {
+            return Promise.resolve();
+        }
+
+        return Promise.reject(
+            new Error(`Розмір файлу не має бути більше ${maxFileSize} MB!`),
+        );
+    }
+
+    return Promise.reject(new Error('Не вдалося перевірити розмір файлу!'));
+};
+
+export default fileSizeValidator;

--- a/src/app/common/components/modals/validators/fileSizeValidator.tsx
+++ b/src/app/common/components/modals/validators/fileSizeValidator.tsx
@@ -1,29 +1,25 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { RuleObject } from 'rc-field-form/lib/interface';
 
+import { UploadFileStatus } from 'antd/es/upload/interface';
+
 import { MaxFileSizeMB } from '@/app/common/constants/enums/file-size.enum';
 
 const fileSizeValidator = (maxFileSize: MaxFileSizeMB) => (_: RuleObject, file: any): Promise<void> => {
-    if (file) {
-        const maxSizeInBytes = maxFileSize * 1024 * 1024;
-        let size = 0;
+    if (file?.file?.status === 'removed' as UploadFileStatus) {
+        return Promise.resolve();
+    }
 
-        if (file.file) {
-            size = file.file.size;
-        } else if (file.size) {
-            size = file.size;
-        }
+    const maxSizeInBytes = maxFileSize * 1024 * 1024;
+    const fileSize = file.file?.size || file.size || 0;
 
-        if (size <= maxSizeInBytes) {
-            return Promise.resolve();
-        }
-
+    if (fileSize > maxSizeInBytes) {
         return Promise.reject(
             new Error(`Розмір файлу не має бути більше ${maxFileSize} MB!`),
         );
     }
 
-    return Promise.reject(new Error('Не вдалося перевірити розмір файлу!'));
+    return Promise.resolve();
 };
 
 export default fileSizeValidator;

--- a/src/app/common/components/modals/validators/imageExtensionValidator.tsx
+++ b/src/app/common/components/modals/validators/imageExtensionValidator.tsx
@@ -2,7 +2,7 @@ import { RuleObject } from 'rc-field-form/lib/interface';
 
 import { SUPPORTED_IMAGE_FILE_TYPES } from '@/app/common/constants/file-types.constants';
 
-const imageValidator = (_: RuleObject, file: any): Promise<void> => {
+const imageExtensionValidator = (_: RuleObject, file: any): Promise<void> => {
     if (file) {
         let name = '';
         if (file.file) {
@@ -25,4 +25,4 @@ const imageValidator = (_: RuleObject, file: any): Promise<void> => {
 
 export const checkImageFileType = (type: string | undefined) => type && SUPPORTED_IMAGE_FILE_TYPES.includes(type);
 
-export default imageValidator;
+export default imageExtensionValidator;

--- a/src/app/common/constants/enums/file-size.enum.ts
+++ b/src/app/common/constants/enums/file-size.enum.ts
@@ -1,0 +1,5 @@
+export enum MaxFileSizeMB {
+    PartnerPhoto = 3,
+}
+
+export default MaxFileSizeMB;

--- a/src/app/common/constants/enums/file-size.enum.ts
+++ b/src/app/common/constants/enums/file-size.enum.ts
@@ -1,5 +1,5 @@
 export enum MaxFileSizeMB {
-    PartnerPhoto = 3,
+    Image = 3,
 }
 
 export default MaxFileSizeMB;

--- a/src/features/AdminPage/CategoriesPage/CategoriesPage/CategoryAdminModal.component.tsx
+++ b/src/features/AdminPage/CategoriesPage/CategoriesPage/CategoryAdminModal.component.tsx
@@ -14,7 +14,7 @@ import Image from '@models/media/image.model';
 import { SourceCategoryAdmin } from '@models/sources/sources.model';
 import useMobx from '@stores/root-store';
 
-import imageValidator, { checkImageFileType } from '@/app/common/components/modals/validators/imageValidator';
+import imageExtensionValidator, { checkImageFileType } from '@components/modals/validators/imageExtensionValidator';
 
 import {
     Button, Form, Input, message, Modal, Popover,
@@ -208,7 +208,7 @@ const SourceModal: React.FC<SourceModalProps> = ({
                         label="Картинка: "
                         rules={[
                             { required: true, message: 'Додайте зображення' },
-                            { validator: imageValidator },
+                            { validator: imageExtensionValidator },
                         ]}
                     >
                         <FileUploader

--- a/src/features/AdminPage/CategoriesPage/CategoriesPage/CategoryAdminModal.component.tsx
+++ b/src/features/AdminPage/CategoriesPage/CategoriesPage/CategoryAdminModal.component.tsx
@@ -28,6 +28,7 @@ import PreviewFileModal from '../../NewStreetcode/MainBlock/PreviewFileModal/Pre
 import POPOVER_CONTENT from '../../JobsPage/JobsModal/constants/popoverContent';
 import uniquenessValidator from '@/app/common/utils/uniquenessValidator';
 import normaliseWhitespaces from '@/app/common/utils/normaliseWhitespaces';
+import combinedImageValidator from "@components/modals/validators/combinedImageValidator";
 
 interface SourceModalProps {
     isModalVisible: boolean;
@@ -164,10 +165,15 @@ const SourceModal: React.FC<SourceModalProps> = ({
 
     const handleInputChange = () => setIsSaveButtonDisabled(false);
 
-    const checkFile = (file: UploadFile) => checkImageFileType(file.type);
+    const checkFile = async (file: UploadFile): Promise<boolean> => {
+        const validator = combinedImageValidator(true);
+        return validator({}, file)
+            .then(() => true)
+            .catch(() => false);
+    };
 
     const handleFileChange = async (param: UploadChangeParam<UploadFile<unknown>>) => {
-        if (checkFile(param.file)) {
+        if (await checkFile(param.file)) {
             setFileList(param.fileList);
         }
         handleInputChange();
@@ -208,7 +214,7 @@ const SourceModal: React.FC<SourceModalProps> = ({
                         label="Картинка: "
                         rules={[
                             { required: true, message: 'Додайте зображення' },
-                            { validator: imageExtensionValidator },
+                            { validator: combinedImageValidator(true) },
                         ]}
                     >
                         <FileUploader

--- a/src/features/AdminPage/NewStreetcode/InterestingFactsBlock/FactsAdminModal/InterestingFactsAdminModal.component.tsx
+++ b/src/features/AdminPage/NewStreetcode/InterestingFactsBlock/FactsAdminModal/InterestingFactsAdminModal.component.tsx
@@ -27,6 +27,7 @@ import PreviewFileModal from '../../MainBlock/PreviewFileModal/PreviewFileModal.
 import { UploadChangeParam } from 'antd/es/upload';
 import POPOVER_CONTENT from '@/features/AdminPage/JobsPage/JobsModal/constants/popoverContent';
 import uniquenessValidator from '@/app/common/utils/uniquenessValidator';
+import combinedImageValidator from "@components/modals/validators/combinedImageValidator";
 
 interface Props {
     fact?: FactCreate,
@@ -43,10 +44,15 @@ const InterestingFactsAdminModal = ({ fact, open, setModalOpen, onChange }: Prop
     const [previewOpen, setPreviewOpen] = useState<boolean>(false);
     const [hasUploadedPhoto, setHasUploadedPhoto] = useState<boolean>(false);
 
-    const checkFile = (file: UploadFile) => checkImageFileType(file.type);
+    const checkFile = async (file: UploadFile): Promise<boolean> => {
+        const validator = combinedImageValidator(true);
+        return validator({}, file)
+            .then(() => true)
+            .catch(() => false);
+    };
 
     const handleFileChange = async (param: UploadChangeParam<UploadFile<unknown>>) => {
-        if (checkFile(param.file)) {
+        if (await checkFile(param.file)) {
             setFileList(param.fileList);
         }
     }
@@ -206,7 +212,7 @@ const InterestingFactsAdminModal = ({ fact, open, setModalOpen, onChange }: Prop
                             name="image"
                             rules={[
                                 { required: true, message: 'Завантажте фото, будь ласка' },
-                                { validator: imageExtensionValidator },
+                                { validator: combinedImageValidator(true) },
                             ]}
                         >
                             <FileUploader

--- a/src/features/AdminPage/NewStreetcode/InterestingFactsBlock/FactsAdminModal/InterestingFactsAdminModal.component.tsx
+++ b/src/features/AdminPage/NewStreetcode/InterestingFactsBlock/FactsAdminModal/InterestingFactsAdminModal.component.tsx
@@ -8,7 +8,7 @@ import getNewMinNegativeId from '@app/common/utils/newIdForStore';
 import CancelBtn from '@assets/images/utils/Cancel_btn.svg';
 import useMobx from '@stores/root-store';
 
-import imageValidator, { checkImageFileType } from '@/app/common/components/modals/validators/imageValidator';
+import imageExtensionValidator, { checkImageFileType } from '@components/modals/validators/imageExtensionValidator';
 
 import {
     Button, Form, Input, message, Modal, Popover, UploadFile,
@@ -206,7 +206,7 @@ const InterestingFactsAdminModal = ({ fact, open, setModalOpen, onChange }: Prop
                             name="image"
                             rules={[
                                 { required: true, message: 'Завантажте фото, будь ласка' },
-                                { validator: imageValidator },
+                                { validator: imageExtensionValidator },
                             ]}
                         >
                             <FileUploader

--- a/src/features/AdminPage/NewStreetcode/MainBlock/FileInputsPart.component.tsx
+++ b/src/features/AdminPage/NewStreetcode/MainBlock/FileInputsPart.component.tsx
@@ -14,6 +14,7 @@ import { UploadChangeParam } from 'antd/es/upload';
 import FormItem from 'antd/es/form/FormItem';
 
 import { RuleObject } from 'antd/es/form';
+import imageExtensionValidator, { checkImageFileType } from '@components/modals/validators/imageExtensionValidator';
 import AudiosApi from '@/app/api/media/audios.api';
 import ImagesApi from '@/app/api/media/images.api';
 import FileUploader from '@/app/common/components/FileUploader/FileUploader.component';
@@ -21,7 +22,6 @@ import base64ToUrl from '@/app/common/utils/base64ToUrl.utility';
 import Audio, { AudioUpdate } from '@/models/media/audio.model';
 
 import PreviewFileModal from './PreviewFileModal/PreviewFileModal.component';
-import imageValidator, { checkImageFileType } from '@/app/common/components/modals/validators/imageValidator';
 
 const convertFileToUploadFile = (file: Image | Audio) => {
     const newFileList: UploadFile = {
@@ -202,7 +202,7 @@ const FileInputsPart = ({ form, onChange }: FileInputsPartProps) => {
         if (!file) {
             return Promise.resolve();
         }
-        return imageValidator(_, file);
+        return imageExtensionValidator(_, file);
     };
 
     return (
@@ -244,7 +244,7 @@ const FileInputsPart = ({ form, onChange }: FileInputsPartProps) => {
                             required: true,
                             message: 'Додайте зображення',
                         },
-                        { validator: imageValidator },
+                        { validator: imageExtensionValidator },
                     ]}
                 >
                     <FileUploader

--- a/src/features/AdminPage/NewStreetcode/StreetcodeArtsBlock/components/Download.component.tsx
+++ b/src/features/AdminPage/NewStreetcode/StreetcodeArtsBlock/components/Download.component.tsx
@@ -21,7 +21,7 @@ import Image from '@/models/media/image.model';
 import Audio from '@/models/media/audio.model';
 
 import PreviewImageModal from './PreviewImageModal/PreviewImageModal.component';
-import { checkImageFileType } from '@components/modals/validators/imageExtensionValidator';
+import combinedImageValidator from "@components/modals/validators/combinedImageValidator";
 
 const DownloadBlock = () => {
     const { id } = useParams<any>();
@@ -33,9 +33,9 @@ const DownloadBlock = () => {
     const [isOpen, setIsOpen] = useState(false);
     const [visibleModal, setVisibleModal] = useState(false);
     const [visibleDeleteButton, setVisibleDeleteButton] = useState(false);
-    const [visibleError, setVisibleError] = useState(false);
     const artsToRemoveIdxs = useRef<Set<string>>(new Set());
     const isSecondRender = useRef<boolean>(false);
+    const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
     useAsync(async () => {
         if (artStore.arts.length === 0 && parseId && !isSecondRender.current) {
@@ -63,7 +63,6 @@ const DownloadBlock = () => {
     
 
     const handleRemove = useCallback((param: UploadFile) => {
-        setVisibleError(false)
         if (isArtInSlides(param.uid)) {
             alert('Ви не можете виділити цей файл для видалення оскільки він є у існуючих слайдах');
             return;
@@ -83,7 +82,6 @@ const DownloadBlock = () => {
     }, []);
 
     const onPreview = async (file: UploadFile) => {
-        setVisibleError(false)
         const artIdx = artStore.arts.findIndex((a) => a.id.toString() === file.uid);
         if (artIdx !== -1) {
             setArtPreviewIdx(artIdx);
@@ -92,7 +90,6 @@ const DownloadBlock = () => {
     };
 
     const onSuccessUploadImage = action((file: Image | Audio) => {
-        setVisibleError(false);
         let image: Image = file as Image;
         const newId = artStore.getMaxArtId + 1;
 
@@ -143,13 +140,17 @@ const DownloadBlock = () => {
         setVisibleDeleteButton(false);
     };
 
-    const handleBeforeUpload = (file: UploadFile) => {
-        const isImage = checkImageFileType(file.type);
-        if (!isImage) {
-            setVisibleError(true);
-        }
-
-        return isImage || Upload.LIST_IGNORE;
+    const beforeFileUpload = async (file: UploadFile) => {
+        const validator = combinedImageValidator(true);
+        return validator({}, file)
+            .then(() => {
+                setErrorMessage(null);
+                return true;
+            })
+            .catch((error: Error) => {
+                setErrorMessage(error.message);
+                return false;
+            });
     };
 
     return (
@@ -160,7 +161,7 @@ const DownloadBlock = () => {
                 fileList={fileList}
                 multiple={true}
                 uploadTo="image"
-                beforeUpload={handleBeforeUpload}
+                beforeUpload={beforeFileUpload}
                 onSuccessUpload={onSuccessUploadImage}
                 onPreview={onPreview}
                 onRemove={handleRemove}
@@ -179,14 +180,13 @@ const DownloadBlock = () => {
             >
                 <p>+ Додати</p>
             </FileUploader>
-            {visibleError &&
-                <Text className="arts-error" type="danger">Тільки файли з розширенням webp, jpeg, png, jpg дозволені!</Text>
-            }
+            {errorMessage
+                && <Text className="arts-error" type="danger">{errorMessage}</Text>}
             {visibleDeleteButton ? (
                 <Button
                     className="delete-arts-button"
                     danger
-                    onClick={() => {setVisibleModal(true);setVisibleError(false)}}
+                    onClick={() => { setVisibleModal(true); }}
                 >
 Видалити
                 </Button>

--- a/src/features/AdminPage/NewStreetcode/StreetcodeArtsBlock/components/Download.component.tsx
+++ b/src/features/AdminPage/NewStreetcode/StreetcodeArtsBlock/components/Download.component.tsx
@@ -21,7 +21,7 @@ import Image from '@/models/media/image.model';
 import Audio from '@/models/media/audio.model';
 
 import PreviewImageModal from './PreviewImageModal/PreviewImageModal.component';
-import { checkImageFileType } from '@/app/common/components/modals/validators/imageValidator';
+import { checkImageFileType } from '@components/modals/validators/imageExtensionValidator';
 
 const DownloadBlock = () => {
     const { id } = useParams<any>();

--- a/src/features/AdminPage/NewsPage/NewsModal/NewsModal.component.tsx
+++ b/src/features/AdminPage/NewsPage/NewsModal/NewsModal.component.tsx
@@ -87,7 +87,7 @@ const NewsModal: React.FC<{
     }, [actionSuccess]);
 
     const createFileListData = (img: Image) => {
-        if (!newsItem) {
+        if (!newsItem || !img) {
             return [];
         }
 

--- a/src/features/AdminPage/NewsPage/NewsModal/NewsModal.component.tsx
+++ b/src/features/AdminPage/NewsPage/NewsModal/NewsModal.component.tsx
@@ -11,6 +11,7 @@ import CancelBtn from '@images/utils/Cancel_btn.svg';
 import { observer } from 'mobx-react-lite';
 import React, { useEffect, useRef, useState } from 'react';
 import ReactQuill from 'react-quill';
+import combinedImageValidator from '@components/modals/validators/combinedImageValidator';
 import PreviewFileModal from '@features/AdminPage/NewStreetcode/MainBlock/PreviewFileModal/PreviewFileModal.component';
 import useMobx from '@stores/root-store';
 import dayjs from 'dayjs';
@@ -26,6 +27,8 @@ import {
     UploadFile,
 } from 'antd';
 import ukUAlocaleDatePicker from 'antd/es/date-picker/locale/uk_UA';
+import { UploadChangeParam } from 'antd/es/upload';
+import { UploadFileStatus } from 'antd/es/upload/interface';
 import ukUA from 'antd/locale/uk_UA';
 
 import {
@@ -66,6 +69,7 @@ const NewsModal: React.FC<{
     const [editorCharacterCount, setEditorCharacterCount] = useState<number>(0);
     const [removedImage, setRemovedImage] = useState<Image | undefined>(undefined);
     const [isSaveButtonDisabled, setIsSaveButtonDisabled] = useState(true);
+    const [fileList, setFileList] = useState<UploadFile[]>([]);
 
     message.config({
         top: 100,
@@ -81,6 +85,22 @@ const NewsModal: React.FC<{
             setActionSuccess(false);
         }
     }, [actionSuccess]);
+
+    const createFileListData = (img: Image) => {
+        if (!newsItem) {
+            return [];
+        }
+
+        return [{
+            name: '',
+            url: base64ToUrl(img.base64, img.mimeType),
+            thumbUrl: base64ToUrl(img.base64, img.mimeType),
+            uid: newsItem!.imageId?.toString(),
+            status: 'done' as UploadFileStatus,
+            type: img.mimeType,
+        }];
+    };
+
     const handlePreview = async (file: UploadFile) => {
         setFilePreview(file);
         setPreviewOpen(true);
@@ -100,7 +120,6 @@ const NewsModal: React.FC<{
         () => newsItem?.title?.trim(),
         'Заголовок вже існує',
     );
-    
 
     useEffect(() => {
         editorRef.current?.editor?.setText('');
@@ -125,6 +144,7 @@ const NewsModal: React.FC<{
             });
             setQuillEditorContent(editorRef.current, newsItem.text);
             setData(newsItem.text);
+            setFileList(createFileListData(newsItem.image!));
         } else {
             imageId.current = 0;
             image.current = undefined;
@@ -149,11 +169,13 @@ const NewsModal: React.FC<{
         if (newsItem) {
             newsItem.image = undefined;
         }
+        setFileList([]);
     };
 
     const closeAndCleanData = () => {
         if (!waitingForApiResponse) {
             form.resetFields();
+            setFileList([]);
             setIsModalOpen(false);
             setRemovedImage(undefined);
             editorRef.current?.editor?.setText('');
@@ -201,7 +223,7 @@ const NewsModal: React.FC<{
             url: formValues.url,
             title: formValues.title,
             text: data ?? '',
-            image: undefined,
+            image: formValues.image,
             creationDate: dayjs(formValues.creationDate),
         };
         newsStore.NewsArray.map((t) => t).forEach((t) => {
@@ -215,7 +237,6 @@ const NewsModal: React.FC<{
             if (newsItem) {
                 news.id = newsItem.id;
                 news.imageId = imageId.current as number;
-
                 await newsStore.updateNews(news);
             } else {
                 await newsStore.createNews(news);
@@ -235,9 +256,35 @@ const NewsModal: React.FC<{
     };
     const handleInputChange = () => setIsSaveButtonDisabled(false);
 
-    const handleUpdate = (value: any) => {
+    const handleUpdate = async (value: any) => {
         setData(value);
         handleInputChange();
+    };
+
+    const beforeFileUpload = async (file: UploadFile): Promise<boolean> => {
+        const validator = combinedImageValidator(true);
+        return validator({}, file)
+            .then(() => true)
+            .catch(() => false);
+    };
+
+    const handleFileChange = async (param: UploadChangeParam<UploadFile<unknown>>) => {
+        if (await beforeFileUpload(param.file)) {
+            setFileList(param.fileList);
+            form.setFieldsValue({ image: fileList });
+        }
+        handleInputChange();
+    };
+
+    const onSuccessFileUpload = async (img: Image | Audio) => {
+        const newFileList = createFileListData(img as Image);
+        form.setFieldsValue({ image: newFileList });
+        imageId.current = img.id;
+        image.current = img as Image;
+        if (newsItem) {
+            newsItem.image = img as Image;
+            newsItem.imageId = img.id;
+        }
     };
 
     return (
@@ -279,7 +326,7 @@ const NewsModal: React.FC<{
                                 { required: true, message: 'Введіть заголовок' },
                                 {
                                     validator: validateTitle,
-                                }                       
+                                },
                             ]}
                         >
                             <Input maxLength={100} showCount onChange={handleInputChange} />
@@ -339,38 +386,10 @@ const NewsModal: React.FC<{
                         <Form.Item
                             name="image"
                             label="Зображення: "
-                            valuePropName="fileList"
-                            getValueFromEvent={(e: any) => {
-                                if (Array.isArray(e)) {
-                                    return e;
-                                }
-                                return e?.fileList;
-                            }}
                             className="image-form-item"
-                            rules={[{
-                                required: true,
-                                message: 'Додайте зображення',
-                            },
-                            {
-                                validator: (_, fileList) => {
-                                    const file = fileList[0]
-                                    if (file) {
-                                        let name = '';
-                                        if (file.file) {
-                                            name = file.file.name.toLowerCase();
-                                        } else if (file.name) {
-                                            name = file.name.toLowerCase();
-                                        }
-                                        if (name.endsWith('.jpeg') || name.endsWith('.png')
-                                            || name.endsWith('.webp') || name.endsWith('.jpg') || name === '') {
-                                            return Promise.resolve();
-                                        }
-                                        // eslint-disable-next-line max-len
-                                        return Promise.reject(Error('Тільки файли з розширенням webp, jpeg, png, jpg дозволені!'));
-                                    }
-                                    return Promise.reject();
-                                },
-                            },
+                            rules={[
+                                { required: true, message: 'Додайте зображення' },
+                                { validator: combinedImageValidator(true) },
                             ]}
                         >
                             <FileUploader
@@ -378,32 +397,16 @@ const NewsModal: React.FC<{
                                 accept=".jpeg,.png,.jpg,.webp"
                                 listType="picture-card"
                                 maxCount={1}
+                                beforeUpload={beforeFileUpload}
                                 onPreview={handlePreview}
+                                fileList={fileList}
                                 uploadTo="image"
-                                onSuccessUpload={(img: Image | Audio) => {
-                                    imageId.current = img.id;
-                                    image.current = img as Image;
-                                    if (newsItem) {
-                                        newsItem.image = img as Image;
-                                    }
-                                }}
+                                onSuccessUpload={onSuccessFileUpload}
                                 onRemove={removeImage}
                                 defaultFileList={
-                                    newsItem?.imageId != null
-                                        ? [
-                                            {
-                                                name: '',
-                                                thumbUrl: base64ToUrl(
-                                                    newsItem?.image?.base64,
-                                                    newsItem?.image?.mimeType,
-                                                ),
-                                                uid: newsItem?.imageId?.toString() || '',
-                                                status: 'done',
-                                            },
-                                        ]
-                                        : []
+                                    newsItem?.image ? createFileListData(newsItem.image) : []
                                 }
-                                                onChange={handleInputChange}
+                                onChange={handleFileChange}
 
                             >
                                 <p>Виберіть чи перетягніть файл</p>
@@ -427,7 +430,7 @@ const NewsModal: React.FC<{
                             <Button
                                 className="streetcode-custom-button"
                                 onClick={() => handleOk()}
-                                                disabled={isSaveButtonDisabled}
+                                disabled={isSaveButtonDisabled}
                             >
                                 Зберегти
                             </Button>

--- a/src/features/AdminPage/PartnersPage/PartnerModal/PartnerModal.component.tsx
+++ b/src/features/AdminPage/PartnersPage/PartnerModal/PartnerModal.component.tsx
@@ -7,8 +7,6 @@ import CancelBtn from '@images/utils/Cancel_btn.svg';
 import { observer } from 'mobx-react-lite';
 import React, { useEffect, useRef, useState } from 'react';
 import { DeleteOutlined, PlusOutlined } from '@ant-design/icons';
-import fileSizeValidator from '@components/modals/validators/fileSizeValidator';
-import MaxFileSizeMB from '@constants/enums/file-size.enum';
 import PreviewFileModal from '@features/AdminPage/NewStreetcode/MainBlock/PreviewFileModal/PreviewFileModal.component';
 import SOCIAL_OPTIONS from '@features/AdminPage/PartnersPage/PartnerModal/constants/socialOptions';
 import useMobx from '@stores/root-store';
@@ -20,8 +18,6 @@ import {
 import FormItem from 'antd/es/form/FormItem';
 import TextArea from 'antd/es/input/TextArea';
 import { UploadChangeParam } from 'antd/es/upload';
-
-import imageExtensionValidator, { checkImageFileType } from '@components/modals/validators/imageExtensionValidator';
 import FileUploader from '@/app/common/components/FileUploader/FileUploader.component';
 import validateSocialLink from '@/app/common/components/modals/validators/socialLinkValidator';
 import base64ToUrl from '@/app/common/utils/base64ToUrl.utility';
@@ -37,6 +33,7 @@ import { StreetcodeShort } from '@/models/streetcode/streetcode-types.model';
 
 // eslint-disable-next-line no-restricted-imports
 import POPOVER_CONTENT from '../../JobsPage/JobsModal/constants/popoverContent';
+import combinedImageValidator from "@components/modals/validators/combinedImageValidator";
 
 const PartnerModal: React.FC< {
     partnerItem?: Partner;
@@ -298,11 +295,7 @@ const PartnerModal: React.FC< {
         };
 
         const checkFile = async (file: UploadFile): Promise<boolean> => {
-            if (!checkImageFileType(file.type)) {
-                return false;
-            }
-
-            const validator = fileSizeValidator(MaxFileSizeMB.Image);
+            const validator = combinedImageValidator(true);
             return validator({}, file)
                 .then(() => true)
                 .catch(() => false);
@@ -407,8 +400,7 @@ const PartnerModal: React.FC< {
                                     required: true,
                                     message: 'Завантажте лого',
                                 },
-                                { validator: imageExtensionValidator },
-                                { validator: fileSizeValidator((MaxFileSizeMB.Image)) },
+                                { validator: combinedImageValidator(true) },
                             ]}
                         >
                             <FileUploader

--- a/src/features/AdminPage/PartnersPage/PartnerModal/PartnerModal.component.tsx
+++ b/src/features/AdminPage/PartnersPage/PartnerModal/PartnerModal.component.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable no-param-reassign */
+/* eslint-disable no-param-reassign,import/extensions */
 import './PartnerModal.styles.scss';
 import '@features/AdminPage/AdminModal.styles.scss';
 
@@ -33,6 +33,7 @@ import Partner, {
 } from '@/models/partners/partners.model';
 import { StreetcodeShort } from '@/models/streetcode/streetcode-types.model';
 
+// eslint-disable-next-line no-restricted-imports
 import POPOVER_CONTENT from '../../JobsPage/JobsModal/constants/popoverContent';
 
 const PartnerModal: React.FC< {
@@ -158,7 +159,7 @@ const PartnerModal: React.FC< {
                 await form.validateFields();
                 form.submit();
                 message.success('Партнера успішно додано!');
-				        setIsSaved(true);
+                setIsSaved(true);
             } catch (error) {
                 setWaitingForApiResponse(false);
                 message.error("Будь ласка, заповніть всі обов'язкові поля та перевірте валідність ваших даних");
@@ -180,10 +181,12 @@ const PartnerModal: React.FC< {
             }
         };
 
+        const handleInputChange = () => setIsSaved(false);
+
         const closeModal = () => {
             if (!waitingForApiResponse) {
                 setIsModalOpen(false);
-								setIsSaved(true);
+                setIsSaved(true);
             }
         };
 
@@ -208,7 +211,7 @@ const PartnerModal: React.FC< {
             partnerLinksForm.resetFields();
             setShowSecondForm(false);
             setShowSecondFormButton(true);
-			      handleInputChange();
+            handleInputChange();
         };
 
         const handleUrlChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -216,7 +219,7 @@ const PartnerModal: React.FC< {
             try {
                 await form.validateFields(['url']);
                 setUrlTitleEnabled(value);
-				        handleInputChange();
+                handleInputChange();
             } catch (error) {
                 setUrlTitleEnabled('');
             }
@@ -227,7 +230,7 @@ const PartnerModal: React.FC< {
         ) => {
             const { value } = e.target;
             setUrlTitleValue(value);
-			      handleInputChange();
+            handleInputChange();
         };
 
         const handleShowSecondForm = () => {
@@ -291,8 +294,6 @@ const PartnerModal: React.FC< {
                 setWaitingForApiResponse(false);
             }
         };
-
-		const handleInputChange = () => setIsSaved(false);
 
         const checkFile = (file: UploadFile) => checkImageFileType(file.type);
 
@@ -429,7 +430,7 @@ const PartnerModal: React.FC< {
                             <Form.Item name="partnersStreetcodes" label="History-коди: ">
                                 <Select
                                     mode="multiple"
-									                  onChange={handleInputChange}
+                                    onChange={handleInputChange}
                                     onSelect={onStreetcodeSelect}
                                     onDeselect={onStreetcodeDeselect}
                                 >

--- a/src/features/AdminPage/PartnersPage/PartnerModal/PartnerModal.component.tsx
+++ b/src/features/AdminPage/PartnersPage/PartnerModal/PartnerModal.component.tsx
@@ -21,8 +21,8 @@ import FormItem from 'antd/es/form/FormItem';
 import TextArea from 'antd/es/input/TextArea';
 import { UploadChangeParam } from 'antd/es/upload';
 
+import imageExtensionValidator, { checkImageFileType } from '@components/modals/validators/imageExtensionValidator';
 import FileUploader from '@/app/common/components/FileUploader/FileUploader.component';
-import imageValidator, { checkImageFileType } from '@/app/common/components/modals/validators/imageValidator';
 import validateSocialLink from '@/app/common/components/modals/validators/socialLinkValidator';
 import base64ToUrl from '@/app/common/utils/base64ToUrl.utility';
 import PartnerLink from '@/features/AdminPage/PartnersPage/PartnerLink.component';
@@ -302,7 +302,7 @@ const PartnerModal: React.FC< {
                 return false;
             }
 
-            const validator = fileSizeValidator(MaxFileSizeMB.PartnerPhoto);
+            const validator = fileSizeValidator(MaxFileSizeMB.Image);
             return validator({}, file)
                 .then(() => true)
                 .catch(() => false);
@@ -407,8 +407,8 @@ const PartnerModal: React.FC< {
                                     required: true,
                                     message: 'Завантажте лого',
                                 },
-                                { validator: imageValidator },
-                                { validator: fileSizeValidator((MaxFileSizeMB.PartnerPhoto)) },
+                                { validator: imageExtensionValidator },
+                                { validator: fileSizeValidator((MaxFileSizeMB.Image)) },
                             ]}
                         >
                             <FileUploader

--- a/src/features/AdminPage/PartnersPage/PartnerModal/PartnerModal.component.tsx
+++ b/src/features/AdminPage/PartnersPage/PartnerModal/PartnerModal.component.tsx
@@ -7,6 +7,8 @@ import CancelBtn from '@images/utils/Cancel_btn.svg';
 import { observer } from 'mobx-react-lite';
 import React, { useEffect, useRef, useState } from 'react';
 import { DeleteOutlined, PlusOutlined } from '@ant-design/icons';
+import fileSizeValidator from '@components/modals/validators/fileSizeValidator';
+import MaxFileSizeMB from '@constants/enums/file-size.enum';
 import PreviewFileModal from '@features/AdminPage/NewStreetcode/MainBlock/PreviewFileModal/PreviewFileModal.component';
 import SOCIAL_OPTIONS from '@features/AdminPage/PartnersPage/PartnerModal/constants/socialOptions';
 import useMobx from '@stores/root-store';
@@ -295,10 +297,19 @@ const PartnerModal: React.FC< {
             }
         };
 
-        const checkFile = (file: UploadFile) => checkImageFileType(file.type);
+        const checkFile = async (file: UploadFile): Promise<boolean> => {
+            if (!checkImageFileType(file.type)) {
+                return false;
+            }
 
-        const handleFileChange = (param: UploadChangeParam<UploadFile<unknown>>) => {
-            if (checkFile(param.file)) {
+            const validator = fileSizeValidator(MaxFileSizeMB.PartnerPhoto);
+            return validator({}, file)
+                .then(() => true)
+                .catch(() => false);
+        };
+
+        const handleFileChange = async (param: UploadChangeParam<UploadFile<unknown>>) => {
+            if (await checkFile(param.file)) {
                 handleInputChange();
                 setFileList(param.fileList);
             }
@@ -397,6 +408,7 @@ const PartnerModal: React.FC< {
                                     message: 'Завантажте лого',
                                 },
                                 { validator: imageValidator },
+                                { validator: fileSizeValidator((MaxFileSizeMB.PartnerPhoto)) },
                             ]}
                         >
                             <FileUploader

--- a/src/features/AdminPage/TeamPage/TeamModal/TeamModal.component.tsx
+++ b/src/features/AdminPage/TeamPage/TeamModal/TeamModal.component.tsx
@@ -32,7 +32,7 @@ import Image from '@/models/media/image.model';
 
 import POPOVER_CONTENT from '../../JobsPage/JobsModal/constants/popoverContent';
 import { UploadChangeParam } from 'antd/es/upload';
-import imageExtensionValidator, { checkImageFileType } from '@components/modals/validators/imageExtensionValidator';
+import combinedImageValidator from "@components/modals/validators/combinedImageValidator";
 
 const TeamModal: React.FC<{
     teamMember?: TeamMember, open: boolean,
@@ -232,10 +232,16 @@ const TeamModal: React.FC<{
 	  const handleInputChange = () => {
 	  	setIsSaveButtonDisabled(false);
   	}
-    const checkFile = (file: UploadFile) => checkImageFileType(file.type);
 
-    const handleFileChange = (param: UploadChangeParam<UploadFile<unknown>>) => {
-        if (checkFile(param.file)) {
+    const checkFile = async (file: UploadFile): Promise<boolean> => {
+        const validator = combinedImageValidator(false);
+        return validator({}, file)
+            .then(() => true)
+            .catch(() => false);
+    };
+
+    const handleFileChange = async (param: UploadChangeParam<UploadFile<unknown>>) => {
+        if (await checkFile(param.file)) {
             setFileList(param.fileList);
         }
         handleInputChange();
@@ -311,7 +317,7 @@ const TeamModal: React.FC<{
                                 required: true,
                                 message: 'Будь ласка, завантажте фото',
                             },
-                            { validator: imageExtensionValidator },
+                            { validator: combinedImageValidator(false) },
                         ]}
                     >
                         <FileUploader

--- a/src/features/AdminPage/TeamPage/TeamModal/TeamModal.component.tsx
+++ b/src/features/AdminPage/TeamPage/TeamModal/TeamModal.component.tsx
@@ -32,7 +32,7 @@ import Image from '@/models/media/image.model';
 
 import POPOVER_CONTENT from '../../JobsPage/JobsModal/constants/popoverContent';
 import { UploadChangeParam } from 'antd/es/upload';
-import imageValidator, { checkImageFileType } from '@/app/common/components/modals/validators/imageValidator';
+import imageExtensionValidator, { checkImageFileType } from '@components/modals/validators/imageExtensionValidator';
 
 const TeamModal: React.FC<{
     teamMember?: TeamMember, open: boolean,
@@ -311,7 +311,7 @@ const TeamModal: React.FC<{
                                 required: true,
                                 message: 'Будь ласка, завантажте фото',
                             },
-                            { validator: imageValidator },
+                            { validator: imageExtensionValidator },
                         ]}
                     >
                         <FileUploader


### PR DESCRIPTION
dev
## JIRA

* [2014](https://github.com/ita-social-projects/StreetCode/issues/2014)
* [2043](https://github.com/ita-social-projects/StreetCode/issues/2043)

## Summary of issue

The problem was that there was no frontend validation for the image size. This allowed files that exceeded the allowed size to pass through without restriction

## Summary of change

Implemented frontend validation for image size to ensure that files exceeding the allowed size are not accepted. The validation was added to the following modals: streetcode creation (photos, art-gallery, wow-facts), partners, team, news


