### PR TITLE
Feature/ issue 2124

### DIFF
--- a/src/app/common/components/modals/Tags/TagsModal.styles.scss
+++ b/src/app/common/components/modals/Tags/TagsModal.styles.scss
@@ -51,8 +51,7 @@ $articlesImg: "@assets/images/sources/Articles.webp";
 
   .relatedFiguresByTagsContentContainer{
     height: pxToRem(598px);
-    @include mut.flexed($direction: row, $gap: 30px, $wrap: wrap);
-
+    @include mut.flexed($direction: row, $align-items: flex-start, $justify-content: flex-start,  $gap: 30px, $wrap: wrap);
     overflow-y: scroll;
     @include mut.rem-margined(0, 21px, 0, 53px);
     @include mut.rem-padded(30px, 0, 30px, 3px);

--- a/src/features/MainPage/TeamSlider/TeamComponent.styles.scss
+++ b/src/features/MainPage/TeamSlider/TeamComponent.styles.scss
@@ -1,6 +1,7 @@
 @use "@sass/mixins/_utils.mixins.scss" as mut;
 @use "@sass/_utils.functions.scss" as f;
 @use "@sass/variables/_variables.colors.scss" as c;
+@use "@assets/sass/variables/_variables.fonts.scss" as ft;
 
 $bgImg: '@assets/images/streetcode-card/background.webp';
 
@@ -52,7 +53,7 @@ $bgImg: '@assets/images/streetcode-card/background.webp';
     }
 
     @media (min-width: 768px) and (max-width: 1024px) {
-        height: 100%;
+        height: auto;
     }
 
     @media screen and (max-width: 1300px) {
@@ -102,11 +103,6 @@ $bgImg: '@assets/images/streetcode-card/background.webp';
         margin-bottom: f.pxToRem(30px);
     }
 
-    .slick-initialized .slick-slide {
-        @include mut.flexed(row, center, center, wrap);
-        @include mut.rem-margined($top: 0px, $right: 20px, $bottom: 10px, $left: 0px);
-    }
-
     .slick-track {
         display: flex !important;
         flex-wrap: nowrap !important;
@@ -133,10 +129,11 @@ $bgImg: '@assets/images/streetcode-card/background.webp';
         cursor: pointer;
         background-color: c.$accented-red-color;
         color: c.$pure-white-color;
-        font-family: Roboto;
-        font-size: 14px;
-        font-style: normal;
-        font-weight: 500;
+        @include mut.with-font(
+            $font-family: ft.$roboto-font,
+            $font-weight: 500,
+            $font-size: 14px,
+            $font-style: normal);
         line-height: normal;
 
         &:hover {

--- a/src/features/StreetcodePage/MainBlock/StreetcodeCard/StreetcodeCard.component.tsx
+++ b/src/features/StreetcodePage/MainBlock/StreetcodeCard/StreetcodeCard.component.tsx
@@ -14,7 +14,6 @@ import { useAudioContext, useModalContext, useStreecodePageLoaderContext } from 
 import { Button } from 'antd';
 
 import ImagesApi from '@/app/api/media/images.api';
-import TransactionLinksApi from '@/app/api/transactions/transactLinks.api';
 import base64ToUrl from '@/app/common/utils/base64ToUrl.utility';
 import { audioClickEvent } from '@/app/common/utils/googleAnalytics.unility';
 import Image, { ImageAssigment } from '@/models/media/image.model';
@@ -32,9 +31,7 @@ const StreetcodeCard = ({ streetcode, setActiveTagId, setShowAllTags }: Props) =
     const audioState = modalsState.audio;
     const streecodePageLoaderContext = useStreecodePageLoaderContext();
     const { fetchAudioByStreetcodeId, audio } = useAudioContext();
-    const [arlink, setArlink] = useState('');
     const [audioIsLoaded, setAudioIsLoaded] = useState<boolean>(false);
-    const [images, setImages] = useState<Image[]>([]);
     const [imagesForSlider, setImagesForSlider] = useState<Image[]>([]);
     const navigate = useNavigate();
 
@@ -50,7 +47,6 @@ const StreetcodeCard = ({ streetcode, setActiveTagId, setShowAllTags }: Props) =
         if (id && id > 0) {
             ImagesApi.getByStreetcodeId(id ?? 1)
                 .then((imgs) => {
-                    setImages(imgs);
                     setImagesForSlider(imgs.filter(
                         (image) => image.imageDetails?.alt === ImageAssigment.blackandwhite.toString()
                         || image.imageDetails?.alt === ImageAssigment.animation.toString(),
@@ -58,7 +54,6 @@ const StreetcodeCard = ({ streetcode, setActiveTagId, setShowAllTags }: Props) =
                     streecodePageLoaderContext.addBlockFetched(StreetcodeBlock.StreetcodeImage);
                 })
                 .catch((e) => { });
-            TransactionLinksApi.getByStreetcodeId(id).then((x) => setArlink(x.url));
         }
     }, [streetcode]);
 
@@ -77,56 +72,58 @@ const StreetcodeCard = ({ streetcode, setActiveTagId, setShowAllTags }: Props) =
         <div className="card">
             <div className="leftSider">
                 <div className="leftSiderContent">
-                    <BlockSlider
-                        arrows={false}
-                        slidesToShow={1}
-                        swipeOnClick
-                        infinite
-                    >
-                        {imagesForSlider.map((image, index) => {
-                            if (imagesForSlider.length > 1 && index === 0) {
-                                return (
-                                    <div>
-                                        <img
-                                            key={imagesForSlider[0].id}
-                                            src={
-                                                base64ToUrl(
-                                                    imagesForSlider[0].base64,
-                                                    imagesForSlider[0].mimeType,
-                                                )
-                                            }
-                                            className="streetcodeImgColored"
-                                            style={{ objectFit: 'contain' }}
-                                            alt={imagesForSlider[0].imageDetails?.alt}
-                                        />
-                                        <img
-                                            key={imagesForSlider[1].id}
-                                            src={base64ToUrl(
-                                                imagesForSlider[1].base64,
-                                                imagesForSlider[1].mimeType,
-                                            )}
-                                            className="streetcodeImgGrey"
-                                            style={{ objectFit: 'contain' }}
-                                            alt={imagesForSlider[1].imageDetails?.alt}
-                                        />
-                                    </div>
-                                );
-                            }
+                    {streecodePageLoaderContext.isPageLoaded ? (
+                        <BlockSlider
+                            arrows={false}
+                            slidesToShow={1}
+                            swipeOnClick
+                            infinite
+                        >
+                            {imagesForSlider.map((image, index) => {
+                                if (imagesForSlider.length > 1 && index === 0) {
+                                    return (
+                                        <div key={image.id}>
+                                            <img
+                                                key={imagesForSlider[0].id}
+                                                src={
+                                                    base64ToUrl(
+                                                        imagesForSlider[0].base64,
+                                                        imagesForSlider[0].mimeType,
+                                                    )
+                                                }
+                                                className="streetcodeImgColored"
+                                                style={{ objectFit: 'contain' }}
+                                                alt={imagesForSlider[0].imageDetails?.alt}
+                                            />
+                                            <img
+                                                key={imagesForSlider[1].id}
+                                                src={base64ToUrl(
+                                                    imagesForSlider[1].base64,
+                                                    imagesForSlider[1].mimeType,
+                                                )}
+                                                className="streetcodeImgGrey"
+                                                style={{ objectFit: 'contain' }}
+                                                alt={imagesForSlider[1].imageDetails?.alt}
+                                            />
+                                        </div>
+                                    );
+                                }
 
-                            return (
-                                <img
-                                    key={imagesForSlider[index].id}
-                                    src={base64ToUrl(
-                                        imagesForSlider[index].base64,
-                                        imagesForSlider[index].mimeType,
-                                    )}
-                                    className="streetcodeImg"
-                                    style={{ objectFit: 'contain' }}
-                                    alt={imagesForSlider[index].imageDetails?.alt}
-                                />
-                            );
-                        })}
-                    </BlockSlider>
+                                return (
+                                    <img
+                                        key={imagesForSlider[index].id}
+                                        src={base64ToUrl(
+                                            imagesForSlider[index].base64,
+                                            imagesForSlider[index].mimeType,
+                                        )}
+                                        className="streetcodeImg"
+                                        style={{ objectFit: 'contain' }}
+                                        alt={imagesForSlider[index].imageDetails?.alt}
+                                    />
+                                );
+                            })}
+                        </BlockSlider>
+                    ) : <></>}
                 </div>
             </div>
             <div className="rightSider">

--- a/src/features/StreetcodePage/MainBlock/StreetcodeCard/StreetcodeCard.styles.scss
+++ b/src/features/StreetcodePage/MainBlock/StreetcodeCard/StreetcodeCard.styles.scss
@@ -9,18 +9,14 @@
     @include mut.rem-padded($top: 0px, $right: 0px, $bottom: 0px, $left: 0px);
     @include mut.sized(1200px, 697px);
     @include mut.full-rounded(50px);
-    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+    box-shadow: 0 4px 4px rgba(0, 0, 0, 0.25);
     line-height: f.pxToRem(19px);
     background-color: c.$pure-white-color;
-
-    .slick-initialized .slick-slide {
-        @include mut.flexed(row, center, center, wrap);
-        @include mut.rem-margined($top: 0px, $right: 0px, $bottom: 10px, $left: 0px);
-    }
 
     .slick-track {
         margin: 0;
     }
+
     .slick-initialized .slick-slide {
       @include mut.flexed($justify-content: center, $gap: 0px);
       @include mut.rem-margined($top: 20px, $right: 0px, $bottom: 10px, $left: 0px);
@@ -65,6 +61,7 @@
 }
 .tagContainer{
   @include mut.rem-margined(13px, 0, 13px, 0);
+  @include mut.flexed($align-items: flex-start, $justify-content: flex-start, $wrap: wrap, $gap: 5px);
 }
 .blurTop{
   @include mut.blur($edge: 0deg, $top: 9px, $height: 16px, $z-index: 3);
@@ -217,7 +214,7 @@
       .leftSider {
         @include mut.sized(360px, 489px);
         flex: 0 0 f.pxToRem(360px);
-        box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+        box-shadow: 0 4px 4px rgba(0, 0, 0, 0.25);
         .leftSiderContent {
           background-color: c.$accented-gray-color;
           @include mut.border(c.$pure-white-color,10px,solid);

--- a/src/features/StreetcodePage/RelatedFiguresBlock/RelatedFigureItem/RelatedFigureItem.styles.scss
+++ b/src/features/StreetcodePage/RelatedFiguresBlock/RelatedFigureItem/RelatedFigureItem.styles.scss
@@ -9,7 +9,7 @@
     @include mut.sized($width: 278px, $height: 380px);
     @include mut.full-rounded($rad: 40px);
     border: 3px solid c.$pure-white-color;
-    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+    box-shadow: 0 4px 4px rgba(0, 0, 0, 0.25);
     background-size: contain;
     background-repeat: no-repeat;
     @include mut.positioned-as();
@@ -71,8 +71,8 @@
     visibility: hidden;
     overflow: hidden;
     max-height: 71px;
-    @include mut.flexed($align-items: center, $gap: 5px, $wrap: wrap);
-    padding: 7px 23px 0px;
+    @include mut.flexed($align-items: center, $justify-content: center, $wrap: wrap, $gap: 5px);
+    padding: 7px 23px 0;
 
     .tag {
         @include mut.sized($height: 28px);
@@ -86,8 +86,6 @@
         p {
             @include mut.sized($height: 14px);
             text-align: center;
-            line-height: 135.69%;
-
             @include mut.with-font($font-size: 10px, $font-weight: 500);
             line-height: pxToRem(13.6px);
             color: c.$pure-white-color;

--- a/src/features/StreetcodePage/Streetcode.component.tsx
+++ b/src/features/StreetcodePage/Streetcode.component.tsx
@@ -6,9 +6,10 @@ import { observer } from 'mobx-react-lite';
 import React, { useEffect, useRef, useState } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { useLocation, useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import Loader from '@components/Loader/Loader.component';
 import ScrollToTopBtn from '@components/ScrollToTopBtn/ScrollToTopBtn.component';
 import ProgressBar from '@features/ProgressBar/ProgressBar.component';
-import { streetcodeDataStore, useModalContext, useStreecodePageLoaderContext, useStreetcodeDataContext } from '@stores/root-store';
+import { useModalContext, useStreecodePageLoaderContext, useStreetcodeDataContext } from '@stores/root-store';
 import DonateBtn from '@streetcode/DonateBtn/DonateBtn.component';
 import MainBlock from '@streetcode/MainBlock/MainBlock.component';
 import QRBlock from '@streetcode/QRBlock/QR.component';
@@ -18,23 +19,21 @@ import TickerBlock from '@streetcode/TickerBlock/Ticker.component';
 import { toStreetcodeRedirectClickEvent } from '@utils/googleAnalytics.unility';
 import { clearWindowHistoryState } from '@utils/window.utility';
 
-import Loader from "@components/Loader/Loader.component";
 import StatisticRecordApi from '@/app/api/analytics/statistic-record.api';
-import StreetcodesApi from '@/app/api/streetcode/streetcodes.api';
 import ArtGallery from '@/app/common/components/ArtGallery/ArtGalleryBlock.component';
 import TagsModalComponent from '@/app/common/components/modals/Tags/TagsModal.component';
 import FRONTEND_ROUTES from '@/app/common/constants/frontend-routes.constants';
 import { useAsync } from '@/app/common/hooks/stateful/useAsync.hook';
 import { useRouteUrl } from '@/app/common/hooks/stateful/useRouter.hook';
 import AuthService from '@/app/common/services/auth-service/AuthService';
+import StreetcodeBlock from '@/models/streetcode/streetcode-blocks.model';
 import Streetcode from '@/models/streetcode/streetcode-types.model';
 
 import InterestingFactsComponent from './InterestingFactsBlock/InterestingFacts.component';
+import MapBlockComponent from './MapBlock/MapBlock.component';
 import PartnersComponent from './PartnersBlock/Partners.component';
 import RelatedFiguresComponent from './RelatedFiguresBlock/RelatedFigures.component';
 import TimelineBlockComponent from './TimelineBlock/TimelineBlock.component';
-import MapBlockComponent from './MapBlock/MapBlock.component';
-import StreetcodeBlock from '@/models/streetcode/streetcode-blocks.model';
 
 const StreetcodeContent = () => {
     const { streetcodeStore } = useStreetcodeDataContext();
@@ -107,7 +106,7 @@ const StreetcodeContent = () => {
         return () => {
             streecodePageLoaderContext.resetLoader();
             streetcodeStore.clearStore();
-        }
+        };
     }, [streetcodeUrlState]);
 
     useEffect(() => {
@@ -129,7 +128,7 @@ const StreetcodeContent = () => {
                 <TextBlockComponent />
                 <InterestingFactsComponent />
                 <TimelineBlockComponent />
-                <MapBlockComponent/>
+                <MapBlockComponent />
                 {streecodePageLoaderContext.isPageLoaded ? (
                     <ArtGallery isFillArtsStore />
                 ) : (


### PR DESCRIPTION


* [Github ticket](https://github.com/ita-social-projects/StreetCode/issues/2124)

## Summary of issue

Previously, due to lazy loading, the animated street code page card would start animating before the loader finished. This caused the animation to be partially complete by the time the page fully loaded

## Summary of change

Now, the animated image loads only after the street code page has fully loaded, ensuring the animation starts at the correct time for a smooth visual experience

## Additional information
Fixed style for tag container on streetcode page


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- The image slider now loads only when content is ready, ensuring a smoother and more reliable viewing experience.

- **Style**
	- Enhanced card design with refined spacing, shadow effects, and improved tag alignment offers a cleaner, more polished interface.
	- Updated flex properties and alignment for various components to improve layout consistency and responsiveness.
	- New font variable integration for improved typography in buttons and components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->