### PR TITLE
Renamed create/edit modal names on admin page

### DIFF
--- a/src/features/AdminPage/CategoriesPage/CategoriesPage/CategoryAdminModal.component.tsx
+++ b/src/features/AdminPage/CategoriesPage/CategoriesPage/CategoryAdminModal.component.tsx
@@ -178,7 +178,7 @@ const SourceModal: React.FC<SourceModalProps> = ({
     return (
         <>
             <Modal
-                title={isEditing ? 'Редагувати категорію' : 'Додати категорію'}
+                title={isEditing ? 'Редагувати категорію' : 'Додати нову категорію'}
                 open={isModalVisible}
                 onCancel={closeModal}
                 className="modalContainer categoryModal"

--- a/src/features/AdminPage/CategoriesPage/CategoriesPage/CategoryAdminModal.component.tsx
+++ b/src/features/AdminPage/CategoriesPage/CategoriesPage/CategoryAdminModal.component.tsx
@@ -178,7 +178,7 @@ const SourceModal: React.FC<SourceModalProps> = ({
     return (
         <>
             <Modal
-                title={isEditing ? 'Редагувати категорію' : 'Додати нову категорію'}
+                title={isEditing ? 'Редагувати категорію' : 'Додати категорію'}
                 open={isModalVisible}
                 onCancel={closeModal}
                 className="modalContainer categoryModal"

--- a/src/features/AdminPage/ContextPage/ContextMainPage.component.spec.tsx
+++ b/src/features/AdminPage/ContextPage/ContextMainPage.component.spec.tsx
@@ -77,7 +77,7 @@ describe('ContextMainPage', () => {
         const addButton = screen.getByText(/додати новий контекст/i);
         userEvent.click(addButton);
         const button = screen.getByText(/зберегти/i);
-        const title = screen.getByRole('heading', {name: /додати новий контекст/i});
+        const title = screen.getByRole('heading', { name: /додати контекст/i });
         const label = screen.getByText(/назва:/i);
         expect(button).toBeInTheDocument();
         expect(title).toBeInTheDocument();

--- a/src/features/AdminPage/ContextPage/ContextModal/ContextAdminModal.component.tsx
+++ b/src/features/AdminPage/ContextPage/ContextModal/ContextAdminModal.component.tsx
@@ -121,7 +121,7 @@ const ContextAdminModalComponent: React.FC<ContextAdminProps> = observer(({
                     onKeyDown={(e) => e.key === 'Enter' ? e.preventDefault() : ''}
                 >
                     <div className="center">
-                        <h2>{isEditing ? 'Редагувати контекст' : 'Додати новий контекст'}</h2>
+                        <h2>{isEditing ? 'Редагувати контекст' : 'Додати контекст'}</h2>
                     </div>
                     <Form.Item
                         name="title"

--- a/src/features/AdminPage/JobsPage/JobsModal/JobsModal.component.tsx
+++ b/src/features/AdminPage/JobsPage/JobsModal/JobsModal.component.tsx
@@ -1,20 +1,23 @@
-import "./JobsModal.styles.scss";
+import './JobsModal.styles.scss';
 
-import { observer } from "mobx-react-lite";
-import { useEffect, useRef, useState } from "react";
-import ReactQuill from "react-quill";
-import CancelBtn from "@assets/images/utils/Cancel_btn.svg";
+import { observer } from 'mobx-react-lite';
+import React, { useEffect, useRef, useState } from 'react';
+import ReactQuill from 'react-quill';
+import CancelBtn from '@assets/images/utils/Cancel_btn.svg';
 
-import { Button, Form, Input, message, Modal, Popover, Select } from "antd";
-
-import JobApi from "@/app/api/job/Job.api";
 import {
-  checkQuillEditorTextLength,
-  setQuillEditorContent,
-} from "@/app/common/components/Editor/EditorUtilities/quillUtils.utility";
-import Editor from "@/app/common/components/Editor/QEditor.component";
+    Button, Form, Input, message, Modal, Popover, Select,
+} from 'antd';
 
-import POPOVER_CONTENT from "./constants/popoverContent";
+import JobApi from '@/app/api/job/Job.api';
+import {
+    checkQuillEditorTextLength,
+    setQuillEditorContent,
+} from '@/app/common/components/Editor/EditorUtilities/quillUtils.utility';
+import Editor from '@/app/common/components/Editor/QEditor.component';
+
+import POPOVER_CONTENT from './constants/popoverContent';
+
 interface Props {
   open: boolean;
   setOpen: React.Dispatch<React.SetStateAction<boolean>>;
@@ -22,199 +25,204 @@ interface Props {
 }
 
 const JobsModal = ({ open, setOpen, currentId }: Props) => {
-  const maxLengths = {
-    maxLenghtVacancyName: 50,
-    maxLenghtVacancyDesc: 2000,
-    maxLenghtVacancySalary: 15,
-  };
+    const maxLengths = {
+        maxLengthVacancyName: 50,
+        maxLengthVacancyDesc: 2000,
+        maxLengthVacancySalary: 15,
+    };
 
-  const [form] = Form.useForm();
+    const [form] = Form.useForm();
 
-  const emptyJob: Job = {
-    title: form.getFieldValue("title"),
-    description: "",
-    status: form.getFieldValue("status") as string === "setActive",
-    id: 0,
-    salary: form.getFieldValue("salary"),
-  };
+    const emptyJob: Job = {
+        title: form.getFieldValue('title'),
+        description: '',
+        status: form.getFieldValue('status') as string === 'setActive',
+        id: 0,
+        salary: form.getFieldValue('salary'),
+    };
 
-  const textEditor = useRef<ReactQuill | null>(null);
-  const [current, setCurrent] = useState<Job>(emptyJob);
-  const [editorCharacterCount, setEditorCharacterCount] = useState<number>(0);
+    const textEditor = useRef<ReactQuill | null>(null);
+    const [current, setCurrent] = useState<Job>(emptyJob);
+    const [editorCharacterCount, setEditorCharacterCount] = useState<number>(0);
+    const [isSaveButtonDisabled, setIsSaveButtonDisabled] = useState(true);
 
-  const [storedJob, setStoredJob] = useState<Job>(emptyJob);
-	const [isSaveButtonDisabled, setIsSaveButtonDisabled] = useState(true);
-
-  const fetchJobData = async () => {
-    if (open && currentId !== 0) {
-      try {
-        const currentJob = await JobApi.getById(currentId);
-        setQuillEditorContent(textEditor.current, currentJob?.description);
-        setCurrent(currentJob);
-        form.setFieldsValue({
-          title: currentJob.title,
-          status: currentJob.status ? "setActive" : "setInactive",
-          description: currentJob.description,
-          salary: currentJob.salary,
-        });
-      } catch (error) {
-        console.error(error);
-      }
-    } else if (currentId === 0) {
-      setStoredJob(emptyJob);
-      form.setFieldsValue({
-        title: emptyJob.title,
-        status: emptyJob.status ? "setActive" : "setInactive",
-        description: emptyJob.description,
-        salary: emptyJob.salary,
-      });
-    }
-  };
-
-  useEffect(() => {
-    textEditor.current?.editor?.setText("");
-    fetchJobData();
-  }, [open, currentId]);
-
-  const handleSave = async () => {
-    try {
-        const values = await form.getFieldsValue();
-        checkQuillEditorTextLength(
-          editorCharacterCount,
-          maxLengths.maxLenghtVacancyDesc
-        );
-        const { title, status, salary } = values;
-        const isActive = status === "setActive";
-
-        const newJob: Job = {
-          id: currentId,
-          title,
-          status: isActive,
-          description: current.description,
-          salary,
-        };
-        const allJobs = await JobApi.getAllShort();
-        allJobs
-          ?.map((t) => t)
-          .forEach((t) => {
-            if (values.title == t.title) newJob.id = t.id;
-          });
-        if (newJob.id === 0) {
-          await JobApi.create(newJob);
-        } else {
-          await JobApi.update(newJob);
+    const fetchJobData = async () => {
+        if (open && currentId !== 0) {
+            try {
+                const currentJob = await JobApi.getById(currentId);
+                setQuillEditorContent(textEditor.current, currentJob?.description);
+                setCurrent(currentJob);
+                form.setFieldsValue({
+                    title: currentJob.title,
+                    status: currentJob.status ? 'setActive' : 'setInactive',
+                    description: currentJob.description,
+                    salary: currentJob.salary,
+                });
+            } catch (error) {
+                console.error(error);
+            }
+        } else if (currentId === 0) {
+            form.setFieldsValue({
+                title: emptyJob.title,
+                status: emptyJob.status ? 'setActive' : 'setInactive',
+                description: emptyJob.description,
+                salary: emptyJob.salary,
+            });
         }
-        message.success(POPOVER_CONTENT.SUCCESS, 2);
+    };
 
-				setIsSaveButtonDisabled(true);
-    } catch {
-      message.error(POPOVER_CONTENT.FAIL, 2);
-    }
-  };
+    useEffect(() => {
+        textEditor.current?.editor?.setText('');
+        fetchJobData();
+    }, [open, currentId]);
 
-  const handleFail = () => {
-    message.error(POPOVER_CONTENT.FAIL, 2);
-  }
+    const handleSave = async () => {
+        try {
+            const values = await form.getFieldsValue();
+            checkQuillEditorTextLength(
+                editorCharacterCount,
+                maxLengths.maxLengthVacancyDesc,
+            );
+            const { title, status, salary } = values;
+            const isActive = status === 'setActive';
 
-  const clearModal = () => {
-    form.resetFields();
-    setOpen(false);
-  };
+            const newJob: Job = {
+                id: currentId,
+                title,
+                status: isActive,
+                description: current.description,
+                salary,
+            };
 
-  const handleEditorChange = (content: string) => {
-    setCurrent({
-      ...current,
-      description: content,
-    });
-		handleInputChange();
-  };
+            const allJobs = await JobApi.getAllShort();
+            allJobs
+                ?.map((t) => t)
+                .forEach((t) => {
+                    if (values.title === t.title) {
+                        newJob.id = t.id;
+                    }
+                });
 
-	const handleInputChange = () => {
-		setIsSaveButtonDisabled(false);
-	}
+            if (newJob.id === 0) {
+                await JobApi.create(newJob);
+            } else {
+                await JobApi.update(newJob);
+            }
 
-  return (
-    <Modal
-      className="modalContainer"
-      open={open}
-      onCancel={() => {
+            message.success(POPOVER_CONTENT.SUCCESS, 2);
+            setIsSaveButtonDisabled(true);
+        } catch {
+            message.error(POPOVER_CONTENT.FAIL, 2);
+        }
+    };
+
+    const handleFail = async () => {
+        message.error(POPOVER_CONTENT.FAIL, 2);
+    };
+
+    const clearModal = () => {
+        form.resetFields();
         setOpen(false);
-				setIsSaveButtonDisabled(true);
-      }}
-      footer={null}
-      maskClosable
-      centered
-      closeIcon={
-        <Popover content={POPOVER_CONTENT.CANCEL} trigger="hover">
-          <CancelBtn className="iconSize" onClick={clearModal} />
-        </Popover>
-      }
-    >
-      <div className="center">
-        <h2>Вакансії</h2>
-      </div>
-      <Form layout="vertical" 
-        form={form} 
-        initialValues={{status: 'setInactive' }} 
-        onFinish={handleSave} 
-        onFinishFailed={handleFail}
-      >
-        <Form.Item
-          label="Назва вакансії"
-          name="title"
-          rules={[{ required: true, message: "Введіть назву вакансії" }]}
-        >
-          <Input showCount maxLength={maxLengths.maxLenghtVacancyName} onChange={handleInputChange} />
-        </Form.Item>
-        <Form.Item label="Статус вакансії" name="status">
-          <Select
-            key="statusSelectInput"
-            className="status-select-input"
-						onChange={handleInputChange}
-          >
-            <Select.Option key="active" value="setActive">
-              Активна
-            </Select.Option>
-            <Select.Option key="inactive" value="setInactive">
-              Не активна
-            </Select.Option>
-          </Select>
-        </Form.Item>
-        <Form.Item
-          label="Опис вакансії"
-          name="description"
-          data-testid="description"
-        >
-          <Editor
-            qRef={textEditor}
-            value={current.description}
-            onChange={handleEditorChange}
-            maxChars={maxLengths.maxLenghtVacancyDesc}
-            onCharacterCountChange={setEditorCharacterCount}
-          />
+    };
 
-        </Form.Item>
-        <Form.Item
-          label="Заробітня плата"
-          name="salary"
-          rules={[{ required: true, message: "Введіть заробітню плату" }]}
+    const handleInputChange = () => {
+        setIsSaveButtonDisabled(false);
+    };
+
+    const handleEditorChange = (content: string) => {
+        setCurrent({
+            ...current,
+            description: content,
+        });
+        handleInputChange();
+    };
+
+    return (
+        <Modal
+            className="modalContainer"
+            open={open}
+            onCancel={() => {
+                setOpen(false);
+                setIsSaveButtonDisabled(true);
+            }}
+            footer={null}
+            maskClosable
+            centered
+            closeIcon={(
+                <Popover content={POPOVER_CONTENT.CANCEL} trigger="hover">
+                    <CancelBtn className="iconSize" onClick={clearModal} />
+                </Popover>
+            )}
         >
-          <Input showCount maxLength={maxLengths.maxLenghtVacancySalary} onChange={handleInputChange} />
-        </Form.Item>
-        <div className="center">
-          <Button
-            className="streetcode-custom-button"
-            onClick={() => {
-							form.submit();
-						}}
-						disabled={isSaveButtonDisabled}
-          >
-            Зберегти
-          </Button>
-        </div>
-      </Form>
-    </Modal>
-  );
+            <div className="center">
+                <h2>
+                    {currentId === 0 ? 'Додати' : 'Редагувати'}
+                    {' '}
+                    вакансію
+                </h2>
+            </div>
+            <Form
+                layout="vertical"
+                form={form}
+                initialValues={{ status: 'setInactive' }}
+                onFinish={handleSave}
+                onFinishFailed={handleFail}
+            >
+                <Form.Item
+                    label="Назва вакансії"
+                    name="title"
+                    rules={[{ required: true, message: 'Введіть назву вакансії' }]}
+                >
+                    <Input showCount maxLength={maxLengths.maxLengthVacancyName} onChange={handleInputChange} />
+                </Form.Item>
+                <Form.Item label="Статус вакансії" name="status">
+                    <Select
+                        key="statusSelectInput"
+                        className="status-select-input"
+                        onChange={handleInputChange}
+                    >
+                        <Select.Option key="active" value="setActive">
+                          Активна
+                        </Select.Option>
+                        <Select.Option key="inactive" value="setInactive">
+                          Не активна
+                        </Select.Option>
+                    </Select>
+                </Form.Item>
+                <Form.Item
+                    label="Опис вакансії"
+                    name="description"
+                    data-testid="description"
+                >
+                    <Editor
+                        qRef={textEditor}
+                        value={current.description}
+                        onChange={handleEditorChange}
+                        maxChars={maxLengths.maxLengthVacancyDesc}
+                        onCharacterCountChange={setEditorCharacterCount}
+                    />
+                </Form.Item>
+                <Form.Item
+                    label="Заробітня плата"
+                    name="salary"
+                    rules={[{ required: true, message: 'Введіть заробітню плату' }]}
+                >
+                    <Input showCount maxLength={maxLengths.maxLengthVacancySalary} onChange={handleInputChange} />
+                </Form.Item>
+                <div className="center">
+                    <Button
+                        className="streetcode-custom-button"
+                        onClick={() => {
+                            form.submit();
+                        }}
+                        disabled={isSaveButtonDisabled}
+                    >
+                      Зберегти
+                    </Button>
+                </div>
+            </Form>
+        </Modal>
+    );
 };
 
 export default observer(JobsModal);

--- a/src/features/AdminPage/NewsPage/NewsModal/NewsModal.component.tsx
+++ b/src/features/AdminPage/NewsPage/NewsModal/NewsModal.component.tsx
@@ -309,7 +309,7 @@ const NewsModal: React.FC<{
                             <h2>
                                 {newsItem ? 'Редагувати' : 'Додати'}
                                 {' '}
-                                Новину
+                                новину
                             </h2>
                         </div>
                         <Form.Item
@@ -434,4 +434,5 @@ const NewsModal: React.FC<{
         </ConfigProvider>
     );
 });
+
 export default NewsModal;

--- a/src/features/AdminPage/PartnersPage/Partners.component.tsx
+++ b/src/features/AdminPage/PartnersPage/Partners.component.tsx
@@ -176,7 +176,7 @@ const Partners: React.FC = observer(() => {
                         className="streetcode-custom-button"
                         onClick={() => setModalAddOpened(true)}
                     >
-                        Створити партнера
+                        Створити нового партнера
                     </Button>
                 </div>
                 <div>

--- a/src/features/AdminPage/TagsPage/TagsPage/TagAdminModal.tsx
+++ b/src/features/AdminPage/TagsPage/TagsPage/TagAdminModal.tsx
@@ -112,7 +112,7 @@ const SourceModal: React.FC<SourceModalProps> = ({
     return (
         <>
             <Modal
-                title={isEditing ? 'Редагувати тег' : 'Додати новий тег'}
+                title={isEditing ? 'Редагувати тег' : 'Додати тег'}
                 open={isModalVisible}
                 onCancel={closeModal}
                 className="modalContainer"

--- a/src/features/AdminPage/TeamPage/TeamModal/TeamModal.component.tsx
+++ b/src/features/AdminPage/TeamPage/TeamModal/TeamModal.component.tsx
@@ -6,6 +6,8 @@ import CancelBtn from '@images/utils/Cancel_btn.svg';
 import { observer } from 'mobx-react-lite';
 import React, { useEffect, useRef, useState } from 'react';
 import { DeleteOutlined, PlusOutlined } from '@ant-design/icons';
+import FileUploader from '@components/FileUploader/FileUploader.component';
+import combinedImageValidator, { checkFile } from '@components/modals/validators/combinedImageValidator';
 import PreviewFileModal from '@features/AdminPage/NewStreetcode/MainBlock/PreviewFileModal/PreviewFileModal.component';
 import SOCIAL_OPTIONS from '@features/AdminPage/TeamPage/TeamModal/constants/socialOptions';
 import TeamMember, {
@@ -19,20 +21,16 @@ import {
     Checkbox,
     Form, Input, message, Modal, Popover, Select, UploadFile,
 } from 'antd';
-
+import { UploadChangeParam } from 'antd/es/upload';
 
 import PositionsApi from '@/app/api/team/teampositions.api';
-import FileUploader from '@components/FileUploader/FileUploader.component';
-
-import base64ToUrl from '@/app/common/utils/base64ToUrl.utility';
 import validateSocialLink from '@/app/common/components/modals/validators/socialLinkValidator';
+import base64ToUrl from '@/app/common/utils/base64ToUrl.utility';
 import TeamLink from '@/features/AdminPage/TeamPage/TeamLink.component';
 import Audio from '@/models/media/audio.model';
 import Image from '@/models/media/image.model';
 
 import POPOVER_CONTENT from '../../JobsPage/JobsModal/constants/popoverContent';
-import { UploadChangeParam } from 'antd/es/upload';
-import combinedImageValidator, { checkFile } from '@components/modals/validators/combinedImageValidator';
 
 const TeamModal: React.FC<{
     teamMember?: TeamMember, open: boolean,
@@ -173,14 +171,14 @@ const TeamModal: React.FC<{
         try {
             await form.validateFields();
             setWaitingForApiResponse(true);
-            await form.submit();
+            form.submit();
             setIsSaveButtonDisabled(true);
         } catch (error) {
             message.error("Будь ласка, заповніть всі обов'язкові поля та перевірте валідність ваших даних");
         }
     };
 
-    const onSuccesfulSubmitPosition = async (formValues: any) => {
+    const onSuccessfulSubmitPosition = async (formValues: any) => {
         message.loading('Зберігання...');
         teamSourceLinks.forEach((el, index) => {
             if (el.id < 0) {
@@ -225,14 +223,14 @@ const TeamModal: React.FC<{
         }
     };
 
+    const handleInputChange = () => {
+        setIsSaveButtonDisabled(false);
+    };
+
     const handleCheckboxChange = (e: { target: { checked: boolean | ((prevState: boolean) => boolean); }; }) => {
         setIsMain(e.target.checked);
         handleInputChange();
     };
-
-	  const handleInputChange = () => {
-	  	setIsSaveButtonDisabled(false);
-  	}
 
     const handleFileChange = async (param: UploadChangeParam<UploadFile<unknown>>) => {
         if (await checkFile(param.file)) {
@@ -257,13 +255,13 @@ const TeamModal: React.FC<{
                 <Form
                     form={form}
                     layout="vertical"
-                    onFinish={onSuccesfulSubmitPosition}
+                    onFinish={onSuccessfulSubmitPosition}
                 >
                     <div className="center">
                         <h2>
                             {teamMember ? 'Редагувати' : 'Додати'}
                             {' '}
-                            нового члена команди
+                            члена команди
                         </h2>
                     </div>
                     <div className="checkbox-container">
@@ -285,7 +283,7 @@ const TeamModal: React.FC<{
                     <Form.Item label="Позиції">
                         <div className="tags-block-positionitems">
                             <Select
-                                aria-label='Позиції'
+                                aria-label="Позиції"
                                 className="positions-select-input"
                                 onSelect={onPositionSelect}
                                 mode="tags"
@@ -359,10 +357,9 @@ const TeamModal: React.FC<{
                             <DeleteOutlined
                                 onClick={() => {
                                     setTeamSourceLinks(teamSourceLinks
-                                        .filter((l) => l.id !== link.id))
+                                        .filter((l) => l.id !== link.id));
                                     handleInputChange();
-                                }
-                                }
+                                }}
                             />
                         </div>
                     ))}
@@ -375,7 +372,7 @@ const TeamModal: React.FC<{
                         style={{ minWidth: '135px' }}
                     >
                         <Select
-                            aria-label='Соціальна мережа'
+                            aria-label="Соціальна мережа"
                             data-testid="logotype-select"
                             options={SOCIAL_OPTIONS}
                             onChange={() => teamLinksForm.validateFields(['url'])}
@@ -417,7 +414,7 @@ const TeamModal: React.FC<{
 
                 <div className="center">
                     <Button
-                        disabled={isSaveButtonDisabled || fileList.length === 0} 
+                        disabled={isSaveButtonDisabled || fileList.length === 0}
                         className="streetcode-custom-button"
                         onClick={handleOk}
                     >
@@ -428,4 +425,5 @@ const TeamModal: React.FC<{
         </Modal>
     );
 });
+
 export default TeamModal;

--- a/src/features/AdminPage/TeamPositionsPage/TeamPositionsMainPage.component.spec.tsx
+++ b/src/features/AdminPage/TeamPositionsPage/TeamPositionsMainPage.component.spec.tsx
@@ -73,7 +73,7 @@ describe('TeamPositionsMainPage', () => {
         const addButton = screen.getByText(/додати нову позицію/i);
         userEvent.click(addButton);
         const button = screen.getByText(/зберегти/i);
-        const title = screen.getByRole('heading', {name: /додати нову позицію/i});
+        const title = screen.getByRole('heading', { name: /додати позицію/i });
         const label = screen.getByText(/назва:/i);
         expect(button).toBeInTheDocument();
         expect(title).toBeInTheDocument();

--- a/src/features/AdminPage/TeamPositionsPage/TeamPositionsModal/TeamPositionsAdminModal.component.tsx
+++ b/src/features/AdminPage/TeamPositionsPage/TeamPositionsModal/TeamPositionsAdminModal.component.tsx
@@ -116,7 +116,7 @@ const TeamPositionsAdminModalComponent: React.FC<TeamPositionsAdminProps> = obse
                     onKeyDown={(e) => e.key === 'Enter' ? e.preventDefault() : ''}
                 >
                     <div className="center">
-                        <h2>{isEditing ? 'Редагувати позицію' : 'Додати нову позицію'}</h2>
+                        <h2>{isEditing ? 'Редагувати позицію' : 'Додати позицію'}</h2>
                     </div>
                     <Form.Item
                         name="position"


### PR DESCRIPTION
## Ticket
- [Main GitHub ticket](https://github.com/ita-social-projects/StreetCode/issues/2136)

## Code reviewers
- [ ] @vlad-zhadan 
- [x] @YuliiaAndreieva 
- [ ] @lisaaksionova 
- [x] @ilko-dev 
- [ ] @YaroslavRosnovskyi 

## Summary of issue
- The modal window for editing a team member and the modal windows for adding and editing job have wrong names.

## Summary of change
- Renamed modal names on admin page.
- Syntactic refactoring of some related files was done.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Revised modal headers and button texts across multiple administrative pages for improved clarity and consistency.

- **New Features**
  - Introduced an enhanced image uploader in the team management modal with improved file validation and dynamic form responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->