### PR TITLE
Centered picture preview

### DIFF
--- a/src/features/AdminPage/NewStreetcode/MainBlock/PreviewFileModal/PreviewFileModal.component.tsx
+++ b/src/features/AdminPage/NewStreetcode/MainBlock/PreviewFileModal/PreviewFileModal.component.tsx
@@ -56,7 +56,12 @@ const PreviewFileModal = ({ opened, setOpened, file, greyFilterForImage = false 
     };
 
     return (
-        <Modal open={opened} footer={null} onCancel={handleCancel}>
+        <Modal
+            open={opened}
+            centered
+            footer={null}
+            onCancel={handleCancel}
+        >
             <div className="modal-item-image">
                 {greyFilterForImage
                     ? previewImage && <img style={{ filter: 'grayscale(100%)' }} alt="uploaded" src={previewImage} />


### PR DESCRIPTION
## Ticket
- [Main GitHub ticket](https://github.com/ita-social-projects/StreetCode/issues/2291)

## Code reviewers
- [ ] @vlad-zhadan 
- [ ] @YuliiaAndreieva 
- [ ] @lisaaksionova 
- [ ] @ilko-dev 
- [ ] @YaroslavRosnovskyi  

## Summary of issue
- When clicking on the image preview, the image does not appear in the middle of the screen.

## Summary of change
- The preview picture is now centered.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The preview dialog now appears centered for a more balanced and visually appealing presentation when viewing previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->