### PR TITLE
The same appearance of modal windows for creating/editing entities on the 'Едітор' page

### DIFF
--- a/src/features/AdminPage/CategoriesPage/CategoriesPage/CategoryAdminModal.component.tsx
+++ b/src/features/AdminPage/CategoriesPage/CategoriesPage/CategoryAdminModal.component.tsx
@@ -8,6 +8,8 @@ import React, {
 } from 'react';
 import ImagesApi from '@api/media/images.api';
 import FileUploader from '@components/FileUploader/FileUploader.component';
+import combinedImageValidator, { checkFile } from '@components/modals/validators/combinedImageValidator';
+import BUTTON_LABELS from '@constants/buttonLabels';
 import { useAsync } from '@hooks/stateful/useAsync.hook';
 import Audio from '@models/media/audio.model';
 import Image from '@models/media/image.model';
@@ -21,13 +23,11 @@ import {
 import { UploadChangeParam, UploadFileStatus } from 'antd/es/upload/interface';
 
 import base64ToUrl from '@/app/common/utils/base64ToUrl.utility';
-
-import PreviewFileModal from '../../NewStreetcode/MainBlock/PreviewFileModal/PreviewFileModal.component';
-import POPOVER_CONTENT from '../../JobsPage/JobsModal/constants/popoverContent';
-import uniquenessValidator from '@/app/common/utils/uniquenessValidator';
 import normaliseWhitespaces from '@/app/common/utils/normaliseWhitespaces';
-import BUTTON_LABELS from "@constants/buttonLabels";
-import combinedImageValidator, { checkFile } from '@components/modals/validators/combinedImageValidator';
+import uniquenessValidator from '@/app/common/utils/uniquenessValidator';
+
+import POPOVER_CONTENT from '../../JobsPage/JobsModal/constants/popoverContent';
+import PreviewFileModal from '../../NewStreetcode/MainBlock/PreviewFileModal/PreviewFileModal.component';
 
 interface SourceModalProps {
     isModalVisible: boolean;
@@ -113,7 +113,7 @@ const SourceModal: React.FC<SourceModalProps> = ({
             image,
         };
         sourcesAdminStore.getSourcesAdmin.map((t) => t).forEach((t) => {
-            if (formData.title == t.title || imageId.current == t.imageId) currentSource.id = t.id;
+            if (formData.title === t.title || imageId.current === t.imageId) currentSource.id = t.id;
         });
 
         if (currentSource.id) {
@@ -149,7 +149,7 @@ const SourceModal: React.FC<SourceModalProps> = ({
                 return;
             }
             form.submit();
-            message.success(`Категорію успішно ${isEditing ? "змінено" : "додано"}!`, 2);
+            message.success(`Категорію успішно ${isEditing ? 'змінено' : 'додано'}!`, 2);
             setIsSaveButtonDisabled(true);
         } catch (error) {
             message.config({
@@ -171,7 +171,7 @@ const SourceModal: React.FC<SourceModalProps> = ({
         handleInputChange();
     };
 
-    const handleRemove = (file: UploadFile) => {
+    const handleRemove = () => {
         setFileList([]);
         setImage(null!);
     };
@@ -179,10 +179,10 @@ const SourceModal: React.FC<SourceModalProps> = ({
     return (
         <>
             <Modal
-                title={isEditing ? 'Редагувати категорію' : 'Додати нову категорію'}
                 open={isModalVisible}
                 onCancel={closeModal}
                 className="modalContainer categoryModal"
+                centered
                 closeIcon={(
                     <Popover content={POPOVER_CONTENT.CANCEL} trigger="hover">
                         <CancelBtn className="iconSize" onClick={handleCancel} />
@@ -190,12 +190,20 @@ const SourceModal: React.FC<SourceModalProps> = ({
                 )}
                 footer={null}
             >
-                <Form form={form} layout="vertical" onFinish={onSubmit} initialValues={initialData}>
+                <Form
+                    form={form}
+                    layout="vertical"
+                    onFinish={onSubmit}
+                    initialValues={initialData}
+                >
+                    <div className="center">
+                        <h2>{isEditing ? 'Редагувати категорію' : 'Додати категорію'}</h2>
+                    </div>
                     <Form.Item
                         name="title"
                         label="Назва: "
                         rules={[{ required: true, message: 'Введіть назву' },
-                        { validator: validateCategory }
+                            { validator: validateCategory },
                         ]}
                         getValueProps={(value) => ({ value: normaliseWhitespaces(value) })}
                     >


### PR DESCRIPTION
## Ticket
- [Main GitHub ticket](https://github.com/ita-social-projects/StreetCode/issues/2343)

## Code reviewers
- [x] @vlad-zhadan 
- [x] @YuliiaAndreieva 
- [ ] @lisaaksionova 
- [ ] @ilko-dev 
- [x] @YaroslavRosnovskyi  

## Summary of issue
- Not the same appearance of creating/editing modal tab windows on the 'Едітор' page.

## Summary of change
- Now all modal windows for creating/editing entities on the 'Editor' page look the same.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated category and tag modals now feature centered headers that dynamically display context-based titles, improving clarity when adding or editing items.
  - Enhanced modal layouts streamline the interface for a better user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->