### PR TITLE
Renamed category image fileds and columns to 'Зображення'

### DIFF
--- a/src/features/AdminPage/CategoriesPage/CategoriesPage.component.tsx
+++ b/src/features/AdminPage/CategoriesPage/CategoriesPage.component.tsx
@@ -77,7 +77,7 @@ const CategoriesMainPage: React.FC = observer(() => {
             title: 'Назва',
             dataIndex: 'title',
             key: 'title',
-            render(value, record) {
+            render(value) {
                 return (
                     <div>
                         {value}
@@ -86,7 +86,7 @@ const CategoriesMainPage: React.FC = observer(() => {
             },
         },
         {
-            title: 'Картинка',
+            title: 'Зображення',
             dataIndex: 'image',
             key: 'image',
             onCell: () => ({
@@ -98,6 +98,7 @@ const CategoriesMainPage: React.FC = observer(() => {
                     className="categories-table-logo"
                     src={base64ToUrl(image?.base64, image?.mimeType ?? '')}
                     style={{ filter: 'grayscale(100%)' }}
+                    alt="Category"
                 />
             ),
         },
@@ -183,4 +184,5 @@ const CategoriesMainPage: React.FC = observer(() => {
 
     );
 });
+
 export default CategoriesMainPage;

--- a/src/features/AdminPage/CategoriesPage/CategoriesPage/CategoryAdminModal.component.tsx
+++ b/src/features/AdminPage/CategoriesPage/CategoriesPage/CategoryAdminModal.component.tsx
@@ -203,7 +203,7 @@ const SourceModal: React.FC<SourceModalProps> = ({
                     </Form.Item>
                     <Form.Item
                         name="image"
-                        label="Картинка: "
+                        label="Зображення: "
                         rules={[
                             { required: true, message: 'Додайте зображення' },
                             { validator: combinedImageValidator(true) },


### PR DESCRIPTION
## Ticket
- [Main GitHub ticket](https://github.com/ita-social-projects/StreetCode/issues/2118)

## Code reviewers
- [ ] @vlad-zhadan 
- [x] @YuliiaAndreieva 
- [x] @lisaaksionova 
- [ ] @ilko-dev 
- [ ] @YaroslavRosnovskyi  

## Summary of issue
- In the modal window "Для фанатів" when creating a new category, the image field has the wrong name.

## Summary of change
- Now, all corresponding columns and fields associated with the category image have been renamed from 'Картинка' to 'Зображення'.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated UI labels for image fields—the header in the categories list and the form label now display “Зображення” for consistent localization.
  - Enhanced accessibility by adding descriptive alternative text to category images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->