### PR TITLE
The 'Зберегти' button responds to form validation.

### DIFF
--- a/src/app/common/components/SubmitButton.component.tsx
+++ b/src/app/common/components/SubmitButton.component.tsx
@@ -1,0 +1,68 @@
+﻿import React, { useEffect, useState } from 'react';
+
+import { Button, Form, FormInstance } from 'antd';
+
+interface SubmitButtonProps {
+    form: FormInstance;
+    initialData?: any;
+    className?: string;
+    name?: string;
+    onClick?: (data: any) => void;
+    disabled?: boolean;
+}
+
+const SubmitButton: React.FC<React.PropsWithChildren<SubmitButtonProps>> = ({
+    form,
+    initialData,
+    className,
+    name,
+    onClick,
+    children,
+    disabled = false,
+}) => {
+    const [submittable, setSubmittable] = useState<boolean>(false);
+    const [hasChanged, setHasChanged] = useState<boolean>(false);
+    const values = Form.useWatch([], form);
+
+    useEffect(() => {
+        if (initialData) {
+            form.resetFields();
+            form.setFieldsValue(initialData);
+        }
+        setHasChanged(false);
+        setSubmittable(false);
+    }, [initialData, form]);
+
+    useEffect(() => {
+        if (initialData && !hasChanged && form.isFieldsTouched(true)) {
+            setHasChanged(true);
+        }
+
+        form
+            .validateFields({ validateOnly: true })
+            .then(() => setSubmittable(true))
+            .catch(() => setSubmittable(false));
+    }, [form, values, initialData, hasChanged]);
+
+    const handleClick = (data: any) => {
+        if (onClick) {
+            onClick(data);
+            setSubmittable(false);
+        }
+    };
+
+    return (
+        <Button
+            type="primary"
+            htmlType="submit"
+            disabled={!submittable || disabled || (initialData && !hasChanged)}
+            className={className}
+            name={name}
+            onClick={handleClick}
+        >
+            {children}
+        </Button>
+    );
+};
+
+export default SubmitButton;

--- a/src/app/common/constants/regex.constants.ts
+++ b/src/app/common/constants/regex.constants.ts
@@ -2,3 +2,6 @@
 export const EMAIL_REGEX = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
 export const NAME_SURNAME_REGEX = /^[a-zA-Zа-яА-ЯґҐєЄіІїЇ'-]+$/;
 export const USERNAME_REGEX = /^[a-z0-9\-'_]+$/;
+export const COMMON_TITLE = /^[a-zA-Zа-яА-ЯґҐєЄіІїЇ'\s]+$/;
+export const NEWS_TRANSLITERATION = /^[a-z0-9-]+$/;
+export const JOB_SALARY = /^[0-9]*$/;

--- a/src/features/AdminPage/ContextPage/ContextModal/ContextAdminModal.component.tsx
+++ b/src/features/AdminPage/ContextPage/ContextModal/ContextAdminModal.component.tsx
@@ -1,15 +1,23 @@
 /* eslint-disable max-len */
 import CancelBtn from '@images/utils/Cancel_btn.svg';
+
 import { observer } from 'mobx-react-lite';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
+import SubmitButton from '@components/SubmitButton.component';
+import BUTTON_LABELS from '@constants/buttonLabels';
+import { COMMON_TITLE } from '@constants/regex.constants';
 import { useAsync } from '@hooks/stateful/useAsync.hook';
 import Context from '@models/additional-content/context.model';
 import useMobx from '@stores/root-store';
-import { Button, Form, Input, message, Modal, Popover, UploadFile } from 'antd';
-import POPOVER_CONTENT from '../../JobsPage/JobsModal/constants/popoverContent';
+
+import {
+    Form, Input, message, Modal, Popover,
+} from 'antd';
+
 import normaliseWhitespaces from '@/app/common/utils/normaliseWhitespaces';
 import uniquenessValidator from '@/app/common/utils/uniquenessValidator';
-import BUTTON_LABELS from "@constants/buttonLabels";
+
+import POPOVER_CONTENT from '../../JobsPage/JobsModal/constants/popoverContent';
 
 interface ContextAdminProps {
     setIsModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
@@ -22,16 +30,14 @@ const ContextAdminModalComponent: React.FC<ContextAdminProps> = observer(({
     isModalVisible,
     setIsModalOpen,
     initialData,
-    isNewContext
+    isNewContext,
 }) => {
-    const {contextStore} = useMobx();
+    const { contextStore } = useMobx();
     const [form] = Form.useForm();
     const isEditing = !!initialData;
-	const [isSaveButtonDisabled, setIsSaveButtonDisabled] = useState(true);
 
     const closeModal = () => {
         setIsModalOpen(false);
-			  setIsSaveButtonDisabled(true);
     };
 
     useAsync(() => contextStore.fetchContexts(), []);
@@ -45,9 +51,9 @@ const ContextAdminModalComponent: React.FC<ContextAdminProps> = observer(({
     }, [initialData, isModalVisible, form]);
 
     const validateContext = uniquenessValidator(
-        ()=>(contextStore.getContextArray.map((context) => context.title)), 
-        ()=>(initialData?.title), 
-        'Контекст з такою назвою вже існує'
+        () => (contextStore.getContextArray.map((context) => context.title)),
+        () => (initialData?.title),
+        'Контекст з такою назвою вже існує',
     );
 
     const onSubmit = async (formData: any) => {
@@ -58,7 +64,9 @@ const ContextAdminModalComponent: React.FC<ContextAdminProps> = observer(({
             title: (formData.title as string).trim(),
         };
 
-        if (currentContext.title === initialData?.title) return;
+        if (currentContext.title === initialData?.title) {
+            return;
+        }
 
         if (currentContext.id) {
             await contextStore.updateContext(currentContext as Context);
@@ -81,7 +89,6 @@ const ContextAdminModalComponent: React.FC<ContextAdminProps> = observer(({
             await form.validateFields();
             form.submit();
             message.success(`Контекст успішно ${isEditing ? 'змінено' : 'додано'}!`);
-			setIsSaveButtonDisabled(true);
         } catch (error) {
             message.config({
                 top: 100,
@@ -96,8 +103,6 @@ const ContextAdminModalComponent: React.FC<ContextAdminProps> = observer(({
     const MAX_LENGTH = {
         title: 50,
     };
-
-		const handleInputChange = () => setIsSaveButtonDisabled(false);
 
     return (
         <Modal
@@ -119,30 +124,36 @@ const ContextAdminModalComponent: React.FC<ContextAdminProps> = observer(({
                     layout="vertical"
                     onFinish={onSubmit}
                     initialValues={initialData}
-                    onKeyDown={(e) => e.key === 'Enter' ? e.preventDefault() : ''}
+                    onKeyDown={(e) => (e.key === 'Enter' ? e.preventDefault() : '')}
                 >
                     <div className="center">
                         <h2>{isEditing ? 'Редагувати контекст' : 'Додати контекст'}</h2>
                     </div>
                     <Form.Item
                         name="title"
-                        label="Назва: "
-                        rules={[{required: true, message: 'Введіть назву', max: MAX_LENGTH.title},
-                            {validator: validateContext}
+                        label="Назва:"
+                        rules={[
+                            { required: true, message: 'Введіть назву', max: MAX_LENGTH.title },
+                            { validator: validateContext },
+                            {
+                                pattern: COMMON_TITLE,
+                                message: 'Назва не повинна містити спеціальних символів або цифр',
+                            },
                         ]}
                         getValueProps={(value) => ({ value: normaliseWhitespaces(value) })}
                     >
-                        <Input maxLength={MAX_LENGTH.title} showCount onChange={handleInputChange} />
+                        <Input maxLength={MAX_LENGTH.title} showCount />
                     </Form.Item>
 
                     <div className="center">
-                        <Button
-							disabled={isSaveButtonDisabled}
+                        <SubmitButton
+                            form={form}
+                            initialData={initialData}
                             className="streetcode-custom-button"
                             onClick={() => handleOk()}
                         >
                             {BUTTON_LABELS.SAVE}
-                        </Button>
+                        </SubmitButton>
                     </div>
                 </Form>
             </div>

--- a/src/features/AdminPage/JobsPage/JobsModal/JobsModal.component.tsx
+++ b/src/features/AdminPage/JobsPage/JobsModal/JobsModal.component.tsx
@@ -4,9 +4,12 @@ import { observer } from 'mobx-react-lite';
 import React, { useEffect, useRef, useState } from 'react';
 import ReactQuill from 'react-quill';
 import CancelBtn from '@assets/images/utils/Cancel_btn.svg';
+import SubmitButton from '@components/SubmitButton.component';
+import BUTTON_LABELS from '@constants/buttonLabels';
+import { JOB_SALARY } from '@constants/regex.constants';
 
 import {
-    Button, Form, Input, message, Modal, Popover, Select,
+    Form, Input, message, Modal, Popover, Select,
 } from 'antd';
 
 import JobApi from '@/app/api/job/Job.api';
@@ -17,7 +20,6 @@ import {
 import Editor from '@/app/common/components/Editor/QEditor.component';
 
 import POPOVER_CONTENT from './constants/popoverContent';
-import BUTTON_LABELS from '@constants/buttonLabels';
 
 interface Props {
   open: boolean;
@@ -45,7 +47,6 @@ const JobsModal = ({ open, setOpen, currentId }: Props) => {
     const textEditor = useRef<ReactQuill | null>(null);
     const [current, setCurrent] = useState<Job>(emptyJob);
     const [editorCharacterCount, setEditorCharacterCount] = useState<number>(0);
-    const [isSaveButtonDisabled, setIsSaveButtonDisabled] = useState(true);
 
     const fetchJobData = async () => {
         if (open && currentId !== 0) {
@@ -111,7 +112,6 @@ const JobsModal = ({ open, setOpen, currentId }: Props) => {
             }
 
             message.success(POPOVER_CONTENT.SUCCESS, 2);
-            setIsSaveButtonDisabled(true);
         } catch {
             message.error(POPOVER_CONTENT.FAIL, 2);
         }
@@ -126,16 +126,11 @@ const JobsModal = ({ open, setOpen, currentId }: Props) => {
         setOpen(false);
     };
 
-    const handleInputChange = () => {
-        setIsSaveButtonDisabled(false);
-    };
-
     const handleEditorChange = (content: string) => {
         setCurrent({
             ...current,
             description: content,
         });
-        handleInputChange();
     };
 
     return (
@@ -144,7 +139,6 @@ const JobsModal = ({ open, setOpen, currentId }: Props) => {
             open={open}
             onCancel={() => {
                 setOpen(false);
-                setIsSaveButtonDisabled(true);
             }}
             footer={null}
             maskClosable
@@ -174,13 +168,12 @@ const JobsModal = ({ open, setOpen, currentId }: Props) => {
                     name="title"
                     rules={[{ required: true, message: 'Введіть назву вакансії' }]}
                 >
-                    <Input showCount maxLength={maxLengths.maxLengthVacancyName} onChange={handleInputChange} />
+                    <Input showCount maxLength={maxLengths.maxLengthVacancyName} />
                 </Form.Item>
                 <Form.Item label="Статус вакансії" name="status">
                     <Select
                         key="statusSelectInput"
                         className="status-select-input"
-                        onChange={handleInputChange}
                     >
                         <Select.Option key="active" value="setActive">
                           Активна
@@ -206,20 +199,25 @@ const JobsModal = ({ open, setOpen, currentId }: Props) => {
                 <Form.Item
                     label="Заробітня плата"
                     name="salary"
-                    rules={[{ required: true, message: 'Введіть заробітню плату' }]}
+                    rules={[
+                        { required: true, message: 'Введіть заробітню плату' },
+                        {
+                            pattern: JOB_SALARY,
+                            message: 'Заробітня плата повинна бути числом',
+                        },
+                    ]}
                 >
-                    <Input showCount maxLength={maxLengths.maxLengthVacancySalary} onChange={handleInputChange} />
+                    <Input showCount maxLength={maxLengths.maxLengthVacancySalary} />
                 </Form.Item>
                 <div className="center">
-                    <Button
+                    <SubmitButton
+                        form={form}
+                        initialData={current}
                         className="streetcode-custom-button"
-                        onClick={() => {
-                            form.submit();
-                        }}
-                        disabled={isSaveButtonDisabled}
+                        onClick={() => form.submit()}
                     >
-                      {BUTTON_LABELS.SAVE}
-                    </Button>
+                        {BUTTON_LABELS.SAVE}
+                    </SubmitButton>
                 </div>
             </Form>
         </Modal>

--- a/src/features/AdminPage/NewStreetcode/CategoriesBlock/CategoriesAdminModal/CategoriesAdminModal.component.tsx
+++ b/src/features/AdminPage/NewStreetcode/CategoriesBlock/CategoriesAdminModal/CategoriesAdminModal.component.tsx
@@ -1,15 +1,17 @@
 import '@features/AdminPage/AdminModal.styles.scss';
 
 import { observer } from 'mobx-react-lite';
-import { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import ReactQuill from 'react-quill';
 import getNewMinNegativeId from '@app/common/utils/newIdForStore';
 import CancelBtn from '@assets/images/utils/Cancel_btn.svg';
+import SubmitButton from '@components/SubmitButton.component';
+import BUTTON_LABELS from '@constants/buttonLabels';
 import { ModelState } from '@models/enums/model-state';
 import useMobx from '@stores/root-store';
 
 import {
-    Button, Form, message, Modal, Popover, Select,
+    Form, message, Modal, Popover, Select,
 } from 'antd';
 
 import SourcesApi from '@/app/api/sources/sources.api';
@@ -19,13 +21,12 @@ import {
 } from '@/app/common/components/Editor/EditorUtilities/quillUtils.utility';
 import Editor from '@/app/common/components/Editor/QEditor.component';
 import SourceModal from '@/features/AdminPage/CategoriesPage/CategoriesPage/CategoryAdminModal.component';
+import POPOVER_CONTENT from '@/features/AdminPage/JobsPage/JobsModal/constants/popoverContent';
 import {
     SourceCategoryName,
     StreetcodeCategoryContent,
     StreetcodeCategoryContentUpdate,
 } from '@/models/sources/sources.model';
-import POPOVER_CONTENT from '@/features/AdminPage/JobsPage/JobsModal/constants/popoverContent';
-import BUTTON_LABELS from "@constants/buttonLabels";
 
 interface Props {
     character_limit?: number;
@@ -58,7 +59,6 @@ const CategoriesModal = ({
     const [textIsChanged, setTextIsChanged] = useState<boolean>(false);
     const [editorCharacterCount, setEditorCharacterCount] = useState<number>(0);
     const maxLength = character_limit || 10000;
-    const [isSaveButtonDisabled, setIsSaveButtonDisabled] = useState(true);
 
     message.config({
         top: 100,
@@ -68,7 +68,7 @@ const CategoriesModal = ({
 
     const getAvailableCategories = async (isNewCat: boolean): Promise<SourceCategoryName[] | undefined> => {
         try {
-            const categories = await SourcesApi.getAllCategories().then(resp => resp.categories);
+            const categories = await SourcesApi.getAllCategories().then((resp) => resp.categories);
             sourcesAdminStore.setInternalSourceCategories(categories);
 
             const selected = sourceCreateUpdateStreetcode.streetcodeCategoryContents
@@ -127,7 +127,6 @@ const CategoriesModal = ({
         if (allPersistedSourcesAreSet) {
             fetchData();
         }
-        setIsSaveButtonDisabled(true);
     }, [open, sourceCreateUpdateStreetcode]);
 
     useEffect(() => {
@@ -147,8 +146,8 @@ const CategoriesModal = ({
         indexOfPersistedCategory: number,
         isEditedCategoryPersisted: boolean,
     ) => {
-        let ids: (number | undefined)[] = sourceCreateUpdateStreetcode.streetcodeCategoryContents.map((x) => x.id);
-        let filteredIds: number[] = ids.filter((id): id is number => id !== undefined);
+        const ids: (number | undefined)[] = sourceCreateUpdateStreetcode.streetcodeCategoryContents.map((x) => x.id);
+        const filteredIds: number[] = ids.filter((id): id is number => id !== undefined);
         if (!isEditedCategoryPersisted) {
             sourceCreateUpdateStreetcode
                 .addSourceCategoryContent({
@@ -230,7 +229,6 @@ const CategoriesModal = ({
             if (validateTextChange()) {
                 form.submit();
                 message.success('Категорію для фанатів успішно додано!');
-                setIsSaveButtonDisabled(true);
             } else {
                 throw new Error();
             }
@@ -240,7 +238,7 @@ const CategoriesModal = ({
     };
 
     const onUpdateStates = async (isNewCatAdded: boolean) => {
-        if (isNewCatAdded === true) {
+        if (isNewCatAdded) {
             const categories = await SourcesApi.getAllNames();
             setCategories(categories.sort((a, b) => a.title.localeCompare(b.title)));
             const AvailableCats = await getAvailableCategories(true);
@@ -255,19 +253,15 @@ const CategoriesModal = ({
             setIsAddModalVisible(true);
             form.resetFields(['category']);
         }
-        handleInputChange();
     };
 
     const handleDisabled = (categoryId: number) => !availableCategories.some((c) => c.id === categoryId);
-
-    const handleInputChange = () => setIsSaveButtonDisabled(false);
 
     return (
         <Modal
             className="modalContainer"
             open={open}
             onCancel={() => {
-                setIsSaveButtonDisabled(true);
                 setOpen(false);
                 sourceCreateUpdateStreetcode.indexUpdate = -1;
             }}
@@ -324,7 +318,6 @@ const CategoriesModal = ({
                         value={editorContent}
                         onChange={(e) => {
                             setEditorContent(e);
-                            handleInputChange();
                         }}
                         maxChars={maxLength}
                         onCharacterCountChange={setEditorCharacterCount}
@@ -334,13 +327,13 @@ const CategoriesModal = ({
                     )}
                 </Form.Item>
                 <div className="center">
-                    <Button
+                    <SubmitButton
+                        form={form}
                         className="streetcode-custom-button"
                         onClick={() => handleOk()}
-                        disabled={isSaveButtonDisabled}
                     >
                         {BUTTON_LABELS.SAVE}
-                    </Button>
+                    </SubmitButton>
                 </div>
             </Form>
         </Modal>

--- a/src/features/AdminPage/NewStreetcode/InterestingFactsBlock/FactsAdminModal/InterestingFactsAdminModal.component.tsx
+++ b/src/features/AdminPage/NewStreetcode/InterestingFactsBlock/FactsAdminModal/InterestingFactsAdminModal.component.tsx
@@ -9,7 +9,7 @@ import CancelBtn from '@assets/images/utils/Cancel_btn.svg';
 import useMobx from '@stores/root-store';
 
 import {
-    Button, Form, Input, message, Modal, Popover, UploadFile,
+    Form, Input, message, Modal, Popover, UploadFile,
 } from 'antd';
 import FormItem from 'antd/es/form/FormItem';
 import TextArea from 'antd/es/input/TextArea';
@@ -27,6 +27,7 @@ import POPOVER_CONTENT from '@/features/AdminPage/JobsPage/JobsModal/constants/p
 import uniquenessValidator from '@/app/common/utils/uniquenessValidator';
 import BUTTON_LABELS from "@constants/buttonLabels";
 import combinedImageValidator, { checkFile } from '@components/modals/validators/combinedImageValidator';
+import SubmitButton from "@components/SubmitButton.component";
 
 interface Props {
     fact?: FactCreate,
@@ -61,10 +62,16 @@ const InterestingFactsAdminModal = ({ fact, open, setModalOpen, onChange }: Prop
         setFileList([]);
     };
 
-    const validateFact = uniquenessValidator(
-        () => (factsStore.getFactArray.map( (fact) => fact.title)),
+    const validateFactTitle = uniquenessValidator(
+        () => (factsStore.getFactArray.map((fact) => fact.title)),
         () => (fact?.title),
         'Факт з такою назвою вже існує',
+    );
+
+    const validateFactContent = uniquenessValidator(
+        () => (factsStore.getFactArray.map((fact) => fact.factContent)),
+        () => (fact?.factContent),
+        'Факт з таким основним текстом вже існує',
     );
 
     useEffect(() => {
@@ -179,9 +186,10 @@ const InterestingFactsAdminModal = ({ fact, open, setModalOpen, onChange }: Prop
                         </div>
                         <Form.Item
                             name="title"
-                            label="Заголовок: "
-                            rules={[{ required: true, message: 'Введіть заголовок, будь ласка' },
-                                { validator: validateFact}
+                            label="Заголовок:"
+                            rules={[
+                                { required: true, message: 'Введіть заголовок, будь ласка' },
+                                { validator: validateFactTitle},
                             ]}
                         >
                             <Input maxLength={68} showCount onChange={(e) => onChange('title', e.target.value)} />
@@ -189,8 +197,11 @@ const InterestingFactsAdminModal = ({ fact, open, setModalOpen, onChange }: Prop
 
                         <Form.Item
                             name="factContent"
-                            label="Основний текст: "
-                            rules={[{ required: true, message: 'Введіть oсновний текст, будь ласка' }]}
+                            label="Основний текст:"
+                            rules={[
+                                { required: true, message: 'Введіть oсновний текст, будь ласка' },
+                                { validator: validateFactContent },
+                            ]}
                         >
                             <TextArea
                                 value="Type"
@@ -236,7 +247,7 @@ const InterestingFactsAdminModal = ({ fact, open, setModalOpen, onChange }: Prop
 
                         <Form.Item
                             name="imageDescription"
-                            label="Підпис фото: "
+                            label="Підпис фото:"
                         >
                             <Input
                                 maxLength={200}
@@ -245,13 +256,13 @@ const InterestingFactsAdminModal = ({ fact, open, setModalOpen, onChange }: Prop
                             />
                         </Form.Item>
                         <div className="center">
-                            <Button
-                                disabled={fileList?.length === 0 || !hasUploadedPhoto}
+                            <SubmitButton
+                                form={form}
                                 className="streetcode-custom-button"
                                 onClick={() => handleOk()}
                             >
                                 {BUTTON_LABELS.SAVE}
-                            </Button>
+                            </SubmitButton>
                         </div>
                     </Form>
                 </div>
@@ -259,7 +270,6 @@ const InterestingFactsAdminModal = ({ fact, open, setModalOpen, onChange }: Prop
             <Popover content="popupContent" trigger="hover" />
             <PreviewFileModal file={fileList?.at(0) ?? null} opened={previewOpen} setOpened={setPreviewOpen} />
         </div>
-
     );
 };
 

--- a/src/features/AdminPage/NewStreetcode/MainBlock/MainBlockAdmin.component.tsx
+++ b/src/features/AdminPage/NewStreetcode/MainBlock/MainBlockAdmin.component.tsx
@@ -15,6 +15,7 @@ import ukUAlocaleDatePicker from 'antd/es/date-picker/locale/uk_UA';
 
 import TagsApi from '@/app/api/additional-content/tags.api';
 import StreetcodesApi from '@/app/api/streetcode/streetcodes.api';
+import SelectWithCustomSuffix from '@/app/common/components/SelectWithCustomSuffix';
 import createTagValidator from '@/app/common/utils/selectValidation.utility';
 import Tag, { StreetcodeTag, StreetcodeTagUpdate } from '@/models/additional-content/tag.model';
 import { StreetcodeType } from '@/models/streetcode/streetcode-types.model';
@@ -23,7 +24,6 @@ import DragableTags from './DragableTags/DragableTags.component';
 import PopoverForTagContent from './PopoverForTagContent/PopoverForTagContent.component';
 import DatePickerPart from './DatePickerPart.component';
 import FileInputsPart from './FileInputsPart.component';
-import SelectWithCustomSuffix from '@/app/common/components/SelectWithCustomSuffix';
 
 interface TagPreviewProps {
     width: number;
@@ -68,7 +68,7 @@ const MainBlockAdmin = React.memo(({
         setErrorMessage,
     );
     const newLineLengthInSymbols = 65;
-    const [teaserValue, setTeaserValue] = useState<string | null>(null);    
+    const [teaserValue, setTeaserValue] = useState<string | null>(null);
 
     const handleInputChange = (fieldName: string, value: unknown) => {
         onChange(fieldName, value);
@@ -150,15 +150,15 @@ const MainBlockAdmin = React.memo(({
         setSelectedTags(selectedTags.filter((t) => t.title !== deselectedValue));
     };
 
-    useEffect (() => {
-        if(!teaserValue){
+    useEffect(() => {
+        if (!teaserValue) {
             setTeaserValue(form.getFieldValue('teaser'));
         }
-    }, [form.getFieldValue('teaser')])
+    }, [form.getFieldValue('teaser')]);
 
     const calculateCustomTeaserSymbolsCount = (teaserValue: string) => {
         const baseSymbolsCount = teaserValue.length;
-        const newLinesCount = (teaserValue.match(/\n/g) || []).length ;
+        const newLinesCount = (teaserValue.match(/\n/g) || []).length;
         return baseSymbolsCount - newLinesCount + newLinesCount * newLineLengthInSymbols;
     };
 
@@ -166,7 +166,7 @@ const MainBlockAdmin = React.memo(({
         const totalCount = calculateCustomTeaserSymbolsCount(value);
 
         if (totalCount > teaserMaxCharCount) {
-            form.setFieldsValue({ [fieldName]: teaserValue })
+            form.setFieldsValue({ [fieldName]: teaserValue });
             return false;
         }
 
@@ -213,7 +213,7 @@ const MainBlockAdmin = React.memo(({
                 ]}
                 name="streetcodeNumber"
             >
-                <InputNumber type='number'/>
+                <InputNumber type="number" />
             </Form.Item>
 
             <div className="display-flex-row p-margin">
@@ -429,16 +429,15 @@ const MainBlockAdmin = React.memo(({
                     rules={[{ required: true, message: 'Введіть тизер'}]}
                 >
                     <Input.TextArea
-                        value={teaserValue || ""}
+                        value={teaserValue || ''}
                         showCount={{
-                            formatter: ({value}) => 
-                                `${calculateCustomTeaserSymbolsCount(value)} / ${teaserMaxCharCount}`
+                            formatter: ({ value }) => `${calculateCustomTeaserSymbolsCount(value)} / ${teaserMaxCharCount}`,
                         }}
                         className="textarea-teaser"
                         onChange={(e) => {
-                            if(handleTeaserChange('teaser', e.target.value)){
-                                handleInputChange(Form.Item.name, e.target.value)
-                            }   
+                            if (handleTeaserChange('teaser', e.target.value)) {
+                                handleInputChange(Form.Item.name, e.target.value);
+                            }
                         }}
                     />
                 </Form.Item>
@@ -447,4 +446,5 @@ const MainBlockAdmin = React.memo(({
         </div>
     );
 });
+
 export default MainBlockAdmin;

--- a/src/features/AdminPage/NewStreetcode/MainNewStreetcode.component.tsx
+++ b/src/features/AdminPage/NewStreetcode/MainNewStreetcode.component.tsx
@@ -18,6 +18,8 @@ import TextsApi from '@app/api/streetcode/text-content/texts.api';
 import useMobx from '@app/stores/root-store';
 import ArtGallery from '@components/ArtGallery/ArtGalleryBlock.component';
 import ArtGalleryDndContext from '@components/ArtGallery/context/ArtGalleryDndContext';
+import SubmitButton from '@components/SubmitButton.component';
+import BUTTON_LABELS from '@constants/buttonLabels';
 import StreetcodeArtsBlock from '@features/AdminPage/NewStreetcode/StreetcodeArtsBlock/StreetcodeArtsBlock.component';
 import PageBar from '@features/AdminPage/PageBar/PageBar.component';
 import StreetcodeCoordinate from '@models/additional-content/coordinate.model';
@@ -66,19 +68,17 @@ import {
     Text,
     TextCreateUpdate,
 } from '@/models/streetcode/text-contents.model';
-import { TransactionLink, TransactionLinkUpdate } from '@/models/transactions/transaction-link.model';
 
 import ARBlock from './ARBlock/ARBlock.component';
 import CategoriesBlock from './CategoriesBlock/CategoriesBlock.component';
 import RelatedFiguresBlock from './HistoryRelations/HistoryRelations.component';
 import InterestingFactsBlock from './InterestingFactsBlock/InterestingFactsBlock.component';
 import MainBlockAdmin from './MainBlock/MainBlockAdmin.component';
+import MapBlockAdmin from './MapBlock/MapBlockAdmin.component';
 import PartnerBlockAdmin from './PartnerBlock/PartnerBlockAdmin.components';
 import SubtitleBlock from './SubtitileBlock/SubtitleBlock.component';
 import TextBlock from './TextBlock/TextBlock.component';
 import TimelineBlockAdmin from './TimelineBlock/TimelineBlockAdmin.component';
-import MapBlockAdmin from './MapBlock/MapBlockAdmin.component';
-import BUTTON_LABELS from "@constants/buttonLabels";
 
 dayjs.extend(utc);
 dayjs.extend(tz);
@@ -696,30 +696,30 @@ const NewStreetcode = () => {
                     </div>
 
                     <div className="submit-button-row">
-                      <Button
-                        className="streetcode-custom-button submit-button"
-                        onClick={onFinish}
-                        name={BUTTON_LABELS.DRAFT}
-                        htmlType="submit"
-                      >
-                        {BUTTON_LABELS.DRAFT}
-                      </Button>
-                      <Modal
-                        title="Ви впевнені, що хочете опублікувати цей history-код?"
-                        open={visibleModal}
-                        onOk={handleModalOk}
-                        onCancel={handleCancelModalRemove}
-                        okText={BUTTON_LABELS.SUBMIT}
-                        cancelText={BUTTON_LABELS.CANCEL}
-                      />
-                      <Button
-                        htmlType="submit"
-                        className="streetcode-custom-button submit-button"
-                        onClick={handleRemove}
-                        name={BUTTON_LABELS.PUBLISH}
-                      >
-                        {BUTTON_LABELS.PUBLISH}
-                      </Button>    
+                        <Button
+                            className="streetcode-custom-button submit-button"
+                            onClick={onFinish}
+                            name={BUTTON_LABELS.DRAFT}
+                            htmlType="submit"
+                        >
+                            {BUTTON_LABELS.DRAFT}
+                        </Button>
+                        <Modal
+                            title="Ви впевнені, що хочете опублікувати цей history-код?"
+                            open={visibleModal}
+                            onOk={handleModalOk}
+                            onCancel={handleCancelModalRemove}
+                            okText={BUTTON_LABELS.SUBMIT}
+                            cancelText={BUTTON_LABELS.CANCEL}
+                        />
+                        <SubmitButton
+                            form={form}
+                            className="streetcode-custom-button submit-button"
+                            name={BUTTON_LABELS.PUBLISH}
+                            onClick={handleRemove}
+                        >
+                            {BUTTON_LABELS.PUBLISH}
+                        </SubmitButton>
                     </div>
                 </div>
             </ConfigProvider>

--- a/src/features/AdminPage/NewsPage/NewsModal/NewsModal.component.tsx
+++ b/src/features/AdminPage/NewsPage/NewsModal/NewsModal.component.tsx
@@ -12,12 +12,14 @@ import { observer } from 'mobx-react-lite';
 import React, { useEffect, useRef, useState } from 'react';
 import ReactQuill from 'react-quill';
 import combinedImageValidator, { checkFile } from '@components/modals/validators/combinedImageValidator';
+import SubmitButton from '@components/SubmitButton.component';
+import BUTTON_LABELS from '@constants/buttonLabels';
+import { NEWS_TRANSLITERATION } from '@constants/regex.constants';
 import PreviewFileModal from '@features/AdminPage/NewStreetcode/MainBlock/PreviewFileModal/PreviewFileModal.component';
 import useMobx from '@stores/root-store';
 import dayjs from 'dayjs';
 
 import {
-    Button,
     ConfigProvider,
     DatePicker,
     Form,
@@ -38,12 +40,12 @@ import {
 import Editor from '@/app/common/components/Editor/QEditor.component';
 import FileUploader from '@/app/common/components/FileUploader/FileUploader.component';
 import base64ToUrl from '@/app/common/utils/base64ToUrl.utility';
+import uniquenessValidator from '@/app/common/utils/uniquenessValidator';
 import Audio from '@/models/media/audio.model';
 import Image from '@/models/media/image.model';
 import News from '@/models/news/news.model';
+
 import POPOVER_CONTENT from '../../JobsPage/JobsModal/constants/popoverContent';
-import uniquenessValidator from '@/app/common/utils/uniquenessValidator';
-import BUTTON_LABELS from "@constants/buttonLabels";
 
 const NewsModal: React.FC<{
     newsItem?: News;
@@ -69,7 +71,6 @@ const NewsModal: React.FC<{
     const [waitingForApiResponse, setWaitingForApiResponse] = useState(false);
     const [editorCharacterCount, setEditorCharacterCount] = useState<number>(0);
     const [removedImage, setRemovedImage] = useState<Image | undefined>(undefined);
-    const [isSaveButtonDisabled, setIsSaveButtonDisabled] = useState(true);
     const [fileList, setFileList] = useState<UploadFile[]>([]);
 
     message.config({
@@ -186,7 +187,6 @@ const NewsModal: React.FC<{
     const closeModal = () => {
         if (!waitingForApiResponse) {
             setIsModalOpen(false);
-            setIsSaveButtonDisabled(true);
             if (removedImage) {
                 imageId.current = removedImage.id;
                 image.current = removedImage;
@@ -209,7 +209,6 @@ const NewsModal: React.FC<{
             checkQuillEditorTextLength(editorCharacterCount, sizeLimit);
             setWaitingForApiResponse(true);
             form.submit();
-            setIsSaveButtonDisabled(true);
         } catch {
             message.error(fillInAllFieldsMessage);
         }
@@ -255,11 +254,9 @@ const NewsModal: React.FC<{
             hideLoadingMessage();
         }
     };
-    const handleInputChange = () => setIsSaveButtonDisabled(false);
 
     const handleUpdate = async (value: any) => {
         setData(value);
-        handleInputChange();
     };
 
     const handleFileChange = async (param: UploadChangeParam<UploadFile<unknown>>) => {
@@ -267,7 +264,6 @@ const NewsModal: React.FC<{
             setFileList(param.fileList);
             form.setFieldsValue({ image: fileList });
         }
-        handleInputChange();
     };
 
     const onSuccessFileUpload = async (img: Image | Audio) => {
@@ -323,7 +319,7 @@ const NewsModal: React.FC<{
                                 },
                             ]}
                         >
-                            <Input maxLength={100} showCount onChange={handleInputChange} />
+                            <Input maxLength={100} showCount />
                         </Form.Item>
 
                         <Form.Item
@@ -332,9 +328,8 @@ const NewsModal: React.FC<{
                             rules={[
                                 { required: true, message: 'Введіть транслітерацію' },
                                 {
-                                    pattern: /^[0-9a-z-]+$/,
-                                    message:
-                                        'Транслітерація має містити лише малі латинські літери, цифри та дефіс',
+                                    pattern: NEWS_TRANSLITERATION,
+                                    message: 'Транслітерація має містити лише малі латинські літери, цифри та дефіс',
                                 },
                                 {
                                     validator: async (_, value) => {
@@ -349,7 +344,7 @@ const NewsModal: React.FC<{
                                 },
                             ]}
                         >
-                            <Input maxLength={200} showCount onChange={handleInputChange} />
+                            <Input maxLength={200} showCount />
                         </Form.Item>
 
                         <Form.Item
@@ -412,7 +407,7 @@ const NewsModal: React.FC<{
                             label="Дата створення: "
                             rules={[{ required: true, message: 'Введіть дату' }]}
                         >
-                            <DatePicker showTime allowClear={false} onChange={handleInputChange} />
+                            <DatePicker showTime allowClear={false} />
                         </Form.Item>
                         <PreviewFileModal
                             opened={previewOpen}
@@ -421,13 +416,14 @@ const NewsModal: React.FC<{
                         />
 
                         <div className="center">
-                            <Button
+                            <SubmitButton
+                                form={form}
+                                initialData={newsItem}
                                 className="streetcode-custom-button"
                                 onClick={() => handleOk()}
-                                disabled={isSaveButtonDisabled}
                             >
                                 {BUTTON_LABELS.SAVE}
-                            </Button>
+                            </SubmitButton>
                         </div>
                     </Form>
                 </div>

--- a/src/features/AdminPage/PartnersPage/PartnerModal/PartnerModal.component.tsx
+++ b/src/features/AdminPage/PartnersPage/PartnerModal/PartnerModal.component.tsx
@@ -7,6 +7,8 @@ import CancelBtn from '@images/utils/Cancel_btn.svg';
 import { observer } from 'mobx-react-lite';
 import React, { useEffect, useRef, useState } from 'react';
 import { DeleteOutlined, PlusOutlined } from '@ant-design/icons';
+import combinedImageValidator, { checkFile } from '@components/modals/validators/combinedImageValidator';
+import SubmitButton from '@components/SubmitButton.component';
 import BUTTON_LABELS from '@constants/buttonLabels';
 import PreviewFileModal from '@features/AdminPage/NewStreetcode/MainBlock/PreviewFileModal/PreviewFileModal.component';
 import SOCIAL_OPTIONS from '@features/AdminPage/PartnersPage/PartnerModal/constants/socialOptions';
@@ -19,10 +21,11 @@ import {
 import FormItem from 'antd/es/form/FormItem';
 import TextArea from 'antd/es/input/TextArea';
 import { UploadChangeParam } from 'antd/es/upload';
-import combinedImageValidator, { checkFile } from '@components/modals/validators/combinedImageValidator';
+
 import FileUploader from '@/app/common/components/FileUploader/FileUploader.component';
 import validateSocialLink from '@/app/common/components/modals/validators/socialLinkValidator';
 import base64ToUrl from '@/app/common/utils/base64ToUrl.utility';
+import uniquenessValidator from '@/app/common/utils/uniquenessValidator';
 import PartnerLink from '@/features/AdminPage/PartnersPage/PartnerLink.component';
 import Audio from '@/models/media/audio.model';
 import Image from '@/models/media/image.model';
@@ -35,7 +38,6 @@ import { StreetcodeShort } from '@/models/streetcode/streetcode-types.model';
 
 // eslint-disable-next-line no-restricted-imports
 import POPOVER_CONTENT from '../../JobsPage/JobsModal/constants/popoverContent';
-import uniquenessValidator from '@/app/common/utils/uniquenessValidator';
 
 const PartnerModal: React.FC< {
     partnerItem?: Partner;
@@ -70,7 +72,6 @@ const PartnerModal: React.FC< {
         const imageId = useRef<number>(0);
         const [actionSuccess, setActionSuccess] = useState(false);
         const [waitingForApiResponse, setWaitingForApiResponse] = useState(false);
-        const [isSaved, setIsSaved] = useState(true);
 
         message.config({
             top: 100,
@@ -141,8 +142,6 @@ const PartnerModal: React.FC< {
             setPreviewOpen(true);
         };
 
-        const handleInputChange = () => setIsSaved(false);
-
         const onStreetcodeSelect = (value: string) => {
             const index = streetcodeShortStore.streetcodes.findIndex(
                 (c) => c.title === value,
@@ -162,7 +161,6 @@ const PartnerModal: React.FC< {
                 await form.validateFields();
                 form.submit();
                 message.success('Партнера успішно додано!');
-                setIsSaved(true);
             } catch (error) {
                 setWaitingForApiResponse(false);
                 message.error("Будь ласка, заповніть всі обов'язкові поля та перевірте валідність ваших даних");
@@ -187,7 +185,6 @@ const PartnerModal: React.FC< {
         const closeModal = () => {
             if (!waitingForApiResponse) {
                 setIsModalOpen(false);
-                setIsSaved(true);
             }
         };
 
@@ -212,7 +209,6 @@ const PartnerModal: React.FC< {
             partnerLinksForm.resetFields();
             setShowSecondForm(false);
             setShowSecondFormButton(true);
-            handleInputChange();
         };
 
         const handleUrlChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -220,7 +216,6 @@ const PartnerModal: React.FC< {
             try {
                 await form.validateFields(['url']);
                 setUrlTitleEnabled(value);
-                handleInputChange();
             } catch (error) {
                 setUrlTitleEnabled('');
             }
@@ -231,7 +226,6 @@ const PartnerModal: React.FC< {
         ) => {
             const { value } = e.target;
             setUrlTitleValue(value);
-            handleInputChange();
         };
 
         const handleShowSecondForm = () => {
@@ -298,7 +292,6 @@ const PartnerModal: React.FC< {
 
         const handleFileChange = async (param: UploadChangeParam<UploadFile<unknown>>) => {
             if (await checkFile(param.file)) {
-                handleInputChange();
                 setFileList(param.fileList);
             }
         };
@@ -336,7 +329,7 @@ const PartnerModal: React.FC< {
                             <h2>
                                 {partnerItem ? 'Редагувати' : 'Додати'}
                                 {' '}
-партнера
+                                партнера
                             </h2>
                         </div>
                         <div className="checkbox-container">
@@ -346,7 +339,7 @@ const PartnerModal: React.FC< {
                                 valuePropName="checked"
                                 label="Ключовий партнер: "
                             >
-                                <Checkbox onChange={handleInputChange} />
+                                <Checkbox />
                             </Form.Item>
 
                             <Form.Item
@@ -355,16 +348,18 @@ const PartnerModal: React.FC< {
                                 valuePropName="checked"
                                 label="Видимий для всіх: "
                             >
-                                <Checkbox onChange={handleInputChange} />
+                                <Checkbox />
                             </Form.Item>
                         </div>
 
                         <Form.Item
                             name="title"
                             label="Назва: "
-                            rules={[{ required: true, message: 'Введіть назву' }, { validator: validateTitle }]}
+                            rules={[
+                                { required: true, message: 'Введіть назву' }, { validator: validateTitle },
+                            ]}
                         >
-                            <Input maxLength={100} showCount onChange={handleInputChange} />
+                            <Input maxLength={100} showCount />
                         </Form.Item>
 
                         <Form.Item
@@ -395,7 +390,7 @@ const PartnerModal: React.FC< {
                         )}
 
                         <Form.Item name="description" label="Опис: ">
-                            <TextArea showCount maxLength={450} onChange={handleInputChange} />
+                            <TextArea showCount maxLength={450} />
                         </Form.Item>
 
                         <Form.Item
@@ -438,7 +433,6 @@ const PartnerModal: React.FC< {
                             <Form.Item name="partnersStreetcodes" label="History-коди: ">
                                 <Select
                                     mode="multiple"
-                                    onChange={handleInputChange}
                                     onSelect={onStreetcodeSelect}
                                     onDeselect={onStreetcodeDeselect}
                                 >
@@ -550,13 +544,15 @@ const PartnerModal: React.FC< {
                             </span>
                         </Popover>
                     ) : (
-                        <Button
-                            disabled={showSecondForm || fileList.length === 0 || isSaved}
+                        <SubmitButton
+                            form={form}
+                            initialData={partnerItem}
                             className="streetcode-custom-button save"
+                            disabled={showSecondForm}
                             onClick={handleOk}
                         >
                             {BUTTON_LABELS.SAVE}
-                        </Button>
+                        </SubmitButton>
                     )}
                 </div>
             </Modal>

--- a/src/features/AdminPage/TeamPage/TeamModal/TeamModal.component.tsx
+++ b/src/features/AdminPage/TeamPage/TeamModal/TeamModal.component.tsx
@@ -9,6 +9,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { DeleteOutlined, PlusOutlined } from '@ant-design/icons';
 import FileUploader from '@components/FileUploader/FileUploader.component';
 import combinedImageValidator, { checkFile } from '@components/modals/validators/combinedImageValidator';
+import SubmitButton from '@components/SubmitButton.component';
 import BUTTON_LABELS from '@constants/buttonLabels';
 import PreviewFileModal from '@features/AdminPage/NewStreetcode/MainBlock/PreviewFileModal/PreviewFileModal.component';
 import SOCIAL_OPTIONS from '@features/AdminPage/TeamPage/TeamModal/constants/socialOptions';
@@ -52,7 +53,6 @@ const TeamModal: React.FC<{
     const [actionSuccess, setActionSuccess] = useState(false);
     const [waitingForApiResponse, setWaitingForApiResponse] = useState(false);
     const imageId = useRef<number>(0);
-    const [isSaveButtonDisabled, setIsSaveButtonDisabled] = useState(true);
     const warningTimeout = useRef<NodeJS.Timeout | null>(null);
     const MAX_POSITION_LENGTH = 50;
 
@@ -166,7 +166,6 @@ const TeamModal: React.FC<{
     const closeModal = () => {
         if (!waitingForApiResponse) {
             setIsModalOpen(false);
-            setIsSaveButtonDisabled(true);
         }
     };
 
@@ -193,7 +192,6 @@ const TeamModal: React.FC<{
             await form.validateFields();
             setWaitingForApiResponse(true);
             form.submit();
-            setIsSaveButtonDisabled(true);
         } catch (error) {
             message.error("Будь ласка, заповніть всі обов'язкові поля та перевірте валідність ваших даних");
         }
@@ -244,20 +242,14 @@ const TeamModal: React.FC<{
         }
     };
 
-    const handleInputChange = () => {
-        setIsSaveButtonDisabled(false);
-    };
-
     const handleCheckboxChange = (e: { target: { checked: boolean | ((prevState: boolean) => boolean); }; }) => {
         setIsMain(e.target.checked);
-        handleInputChange();
     };
 
     const handleFileChange = async (param: UploadChangeParam<UploadFile<unknown>>) => {
         if (await checkFile(param.file)) {
             setFileList(param.fileList);
         }
-        handleInputChange();
     };
 
     return (
@@ -298,7 +290,7 @@ const TeamModal: React.FC<{
                         label="Прізвище та ім'я: "
                         rules={[{ required: true, message: "Введіть прізвище та ім'я" }]}
                     >
-                        <Input maxLength={41} showCount onChange={handleInputChange} />
+                        <Input maxLength={41} showCount />
                     </Form.Item>
 
                     <Form.Item label="Позиції">
@@ -310,7 +302,6 @@ const TeamModal: React.FC<{
                                 mode="tags"
                                 onDeselect={onPositionDeselect}
                                 value={selectedPositions.map((x) => x.position)}
-                                onChange={handleInputChange}
                                 options={positions.map((t) => ({ value: t.position, label: t.position }))}
                                 onInputKeyDown={handleInputKeyDown}
                             />
@@ -320,7 +311,7 @@ const TeamModal: React.FC<{
                         name="description"
                         label="Опис: "
                     >
-                        <Input.TextArea showCount maxLength={70} onChange={handleInputChange} />
+                        <Input.TextArea showCount maxLength={70} />
                     </Form.Item>
 
                     <Form.Item
@@ -380,7 +371,6 @@ const TeamModal: React.FC<{
                                 onClick={() => {
                                     setTeamSourceLinks(teamSourceLinks
                                         .filter((l) => l.id !== link.id));
-                                    handleInputChange();
                                 }}
                             />
                         </div>
@@ -428,20 +418,21 @@ const TeamModal: React.FC<{
                     >
                         <Popover content="Додати" trigger="hover">
                             <Button htmlType="submit" className="plus-button" data-testid="add-button">
-                                <PlusOutlined onClick={handleInputChange} />
+                                <PlusOutlined />
                             </Button>
                         </Popover>
                     </Form.Item>
                 </div>
 
                 <div className="center">
-                    <Button
-                        disabled={isSaveButtonDisabled || fileList.length === 0}
+                    <SubmitButton
+                        form={form}
+                        initialData={teamMember}
                         className="streetcode-custom-button"
                         onClick={handleOk}
                     >
                         {BUTTON_LABELS.SAVE}
-                    </Button>
+                    </SubmitButton>
                 </div>
             </Form>
         </Modal>

--- a/src/features/AdminPage/TeamPositionsPage/TeamPositionsModal/TeamPositionsAdminModal.component.tsx
+++ b/src/features/AdminPage/TeamPositionsPage/TeamPositionsModal/TeamPositionsAdminModal.component.tsx
@@ -1,16 +1,21 @@
 /* eslint-disable max-len */
 import CancelBtn from '@images/utils/Cancel_btn.svg';
+
 import { observer } from 'mobx-react-lite';
-import { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
+import SubmitButton from '@components/SubmitButton.component';
+import BUTTON_LABELS from '@constants/buttonLabels';
+import { COMMON_TITLE } from '@constants/regex.constants';
 import { useAsync } from '@hooks/stateful/useAsync.hook';
 import Position from '@models/additional-content/teampositions.model';
 import useMobx from '@stores/root-store';
-import { Button, Form, Input, message, Modal, Popover, UploadFile } from 'antd';
-import {parseJsonNumber} from "ajv/dist/runtime/parseJson";
-import position = parseJsonNumber.position;
+
+import {
+    Form, Input, message, Modal, Popover,
+} from 'antd';
+
 import normaliseWhitespaces from '@/app/common/utils/normaliseWhitespaces';
 import uniquenessValidator from '@/app/common/utils/uniquenessValidator';
-import BUTTON_LABELS from "@constants/buttonLabels";
 
 interface TeamPositionsAdminProps {
     setIsModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
@@ -23,11 +28,12 @@ const TeamPositionsAdminModalComponent: React.FC<TeamPositionsAdminProps> = obse
     isModalVisible,
     setIsModalOpen,
     initialData,
-    isNewPosition
+    isNewPosition,
 }) => {
-    const {teamPositionsStore} = useMobx();
+    const { teamPositionsStore } = useMobx();
     const [form] = Form.useForm();
     const isEditing = !!initialData;
+
     const closeModal = () => {
         setIsModalOpen(false);
     };
@@ -43,9 +49,9 @@ const TeamPositionsAdminModalComponent: React.FC<TeamPositionsAdminProps> = obse
     }, [initialData, isModalVisible, form]);
 
     const validatePosition = uniquenessValidator(
-        ()=>(teamPositionsStore.getPositionsArray.map((position) => position.position)), 
-        ()=>(initialData?.position), 
-        'Позиція з такою назвою вже існує'
+        () => (teamPositionsStore.getPositionsArray.map((position) => position.position)),
+        () => (initialData?.position),
+        'Позиція з такою назвою вже існує',
     );
 
     const onSubmit = async (formData: any) => {
@@ -56,7 +62,9 @@ const TeamPositionsAdminModalComponent: React.FC<TeamPositionsAdminProps> = obse
             position: (formData.position as string).trim(),
         };
 
-        if (currentPosition.position === initialData?.position) return;
+        if (currentPosition.position === initialData?.position) {
+            return;
+        }
 
         if (currentPosition.id) {
             await teamPositionsStore.updatePosition(currentPosition as Position);
@@ -114,29 +122,36 @@ const TeamPositionsAdminModalComponent: React.FC<TeamPositionsAdminProps> = obse
                     layout="vertical"
                     onFinish={onSubmit}
                     initialValues={initialData}
-                    onKeyDown={(e) => e.key === 'Enter' ? e.preventDefault() : ''}
+                    onKeyDown={(e) => (e.key === 'Enter' ? e.preventDefault() : '')}
                 >
                     <div className="center">
                         <h2>{isEditing ? 'Редагувати позицію' : 'Додати позицію'}</h2>
                     </div>
                     <Form.Item
                         name="position"
-                        label="Назва: "
-                        rules={[{required: true, message: 'Введіть назву', max: MAX_LENGTH.title},
-                            {validator: validatePosition}
+                        label="Назва:"
+                        rules={[
+                            { required: true, message: 'Введіть назву', max: MAX_LENGTH.title },
+                            { validator: validatePosition },
+                            {
+                                pattern: COMMON_TITLE,
+                                message: 'Назва не повинна містити спеціальних символів або цифр',
+                            },
                         ]}
                         getValueProps={(value) => ({ value: normaliseWhitespaces(value) })}
                     >
-                        <Input maxLength={MAX_LENGTH.title} showCount/>
+                        <Input maxLength={MAX_LENGTH.title} showCount />
                     </Form.Item>
 
                     <div className="center">
-                        <Button
+                        <SubmitButton
+                            form={form}
+                            initialData={initialData}
                             className="streetcode-custom-button"
                             onClick={() => handleOk()}
                         >
                             {BUTTON_LABELS.SAVE}
-                        </Button>
+                        </SubmitButton>
                     </div>
                 </Form>
             </div>


### PR DESCRIPTION
## Tickets
- [GitHub ticket 1](https://github.com/ita-social-projects/StreetCode/issues/2130)
- [GitHub ticket 2](https://github.com/ita-social-projects/StreetCode/issues/2127)
- [GitHub ticket 3](https://github.com/ita-social-projects/StreetCode/issues/1813)

## Code reviewers
- [ ] @vlad-zhadan 
- [ ] @YuliiaAndreieva 
- [ ] @lisaaksionova 
- [ ] @ilko-dev 
- [ ] @YaroslavRosnovskyi 

## Summary of issue
- Button 'Зберегти' becomes active when all mandatory fields are not filled in.
- The "Зберегти" button is active even if the fields are filled with non-unique data in the "Wow-факти" and "Хронологія" modal windows.

## Summary of change
- Now the 'Зберегти' button responds to form validation.
- Added additional uniqueness checks for some fields from the "Wow-факти" and "Хронологія" forms.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions