### PR TITLE
Solved problem with incorrect tag editing/creating modal window uniqu…

### DIFF
--- a/src/features/AdminPage/TagsPage/TagsPage/TagAdminModal.tsx
+++ b/src/features/AdminPage/TagsPage/TagsPage/TagAdminModal.tsx
@@ -61,7 +61,7 @@ const SourceModal: React.FC<SourceModalProps> = ({
     };
 
     const validateTag = uniquenessValidator(
-        () => (tagsStore.getTagArray.map((tag) => tag.title)),
+        () => (tagsStore.getAllTagsArray.map((tag) => tag.title)),
         () => (initialData?.title),
         'Тег з такою назвою вже існує',
     );
@@ -74,7 +74,9 @@ const SourceModal: React.FC<SourceModalProps> = ({
             title: (formData.title as string).trim(),
         };
 
-        if (currentTag.title === initialData?.title) return;
+        if (currentTag.title === initialData?.title) {
+            return;
+        }
 
         if (currentTag.id) {
             await tagsStore.updateTag(currentTag as Tag);
@@ -136,7 +138,8 @@ const SourceModal: React.FC<SourceModalProps> = ({
                 <Form.Item
                     name="title"
                     label="Назва: "
-                    rules={[{ required: true, message: 'Введіть назву' },
+                    rules={[
+                        { required: true, message: 'Введіть назву' },
                         { validator: validateTag },
                     ]}
                     getValueProps={(value: string) => ({ value: normaliseWhitespaces(value) })}


### PR DESCRIPTION
## Ticket
- [GitHub ticket 1](https://github.com/ita-social-projects/StreetCode/issues/2544)
- [GitHub ticket 2](https://github.com/ita-social-projects/StreetCode/issues/2545)

❗❗❗ATTENTION: related [PR](https://github.com/ita-social-projects/StreetCode_Client/pull/1550). Make sure to merge them together to solve issues completely.❗❗❗

## Code reviewers
- [ ] @vlad-zhadan 
- [ ] @YuliiaAndreieva 
- [ ] @ilko-dev 
- [ ] @YaroslavRosnovskyi 
- [ ] @ihor-yatsyshyn 
- [ ] @ZhmudAnastasiia 
- [ ] @IceStorman 
- [ ] @yaroslav-vasylyshyn 

## Summary of issue
1. The forms for creating/editing tags was not reacting properly if we already had an existing tag with that name.

## Summary of change
1. Now we is a proper check for the uniqueness of the tag when trying to create/edit it. If there is the above validation error, the `submit` button is painted gray.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions