### PR TITLE
Feature/issue-2365

### DIFF
--- a/src/features/AdminPage/NewStreetcode/MainNewStreetcode.component.tsx
+++ b/src/features/AdminPage/NewStreetcode/MainNewStreetcode.component.tsx
@@ -411,7 +411,6 @@ const NewStreetcode = () => {
                             .utc(form.getFieldValue('streetcodeSecondDate'))
                             .toDate()
                         : null,
-                    imagesIds: createUpdateMediaStore.getImageIds(),
                     audioId: createUpdateMediaStore.audioId,
                     tags: reindex(selectedTags).map((tag) => ({
                         ...tag,

--- a/src/models/streetcode/streetcode-types.model.ts
+++ b/src/models/streetcode/streetcode-types.model.ts
@@ -121,7 +121,6 @@ export interface StreetcodeCreate {
     eventEndOrPersonDeathDate: Date | null,
     dateString: string,
     tags: StreetcodeTag[],
-    imagesIds: Array<number>,
     audioId: number | null,
     streetcodeType: StreetcodeType,
     text: TextCreateUpdate | null,


### PR DESCRIPTION
dev
## JIRA

* [2365](https://github.com/ita-social-projects/StreetCode/issues/2365)

## Summary of issue

There was redundant imageIds array in streetcode creation request
Notice that the ticket also describes similar problem in news and category creation requests, but no redundant arrays were found

## Summary of change

Removed imageIds array from request and added id mapping from imageDetails array

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the process for creating new streetcodes by removing the need to specify image IDs during creation. This streamlines the creation form and payload for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->