### PR TITLE
Feature/issue 2698

### DIFF
--- a/src/app/common/components/modals/Lightbox/Lightbox.component.tsx
+++ b/src/app/common/components/modals/Lightbox/Lightbox.component.tsx
@@ -1,6 +1,6 @@
 import './LightboxComponent.styles.scss';
 import { observer } from 'mobx-react-lite';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useIdleTimer } from 'react-idle-timer';
 import useMobx, { useModalContext } from '@stores/root-store';
 import Lightbox from 'yet-another-react-lightbox';
@@ -10,66 +10,89 @@ import 'yet-another-react-lightbox/plugins/thumbnails.css';
 import 'yet-another-react-lightbox/plugins/captions.css';
 import 'yet-another-react-lightbox/styles.css';
 
-const TitleDescriptionComponent = ({ title, description }: { title: string| undefined, description: string| undefined }) => {
-  return (
-    <div>
-      <div className="title">{title}</div>
-      <div className="description">{description}</div>
-    </div>
-  );
+const TitleDescriptionComponent = ({ title, description }: { title: string | undefined, description: string | undefined }) => {
+    return (
+        <div>
+            <div className="title">{title}</div>
+            <div className="description">{description}</div>
+        </div>
+    );
 };
 
-
 const LightboxComponent = () => {
-    const { streetcodeArtSlideStore: {streetcodeArtSlides}} = useMobx();
+    const { streetcodeArtSlideStore: { streetcodeArtSlides } } = useMobx();
     const { artStore: { mutationObserved } } = useMobx();
     const { modalStore } = useModalContext();
     const { setModal, modalsState: { artGallery: { isOpen, fromCardId } } } = modalStore;
 
-    const arts = streetcodeArtSlides.flatMap((artslide) => (artslide.streetcodeArts.flatMap((art) => (art.art))))
+    const arts = streetcodeArtSlides.flatMap((artslide) =>
+        artslide.streetcodeArts.flatMap((art) => art.art)
+    );
 
-  const [isCaptionEnabled, setIsCaptionEnabled] = useState(true);
+    const [isCaptionEnabled, setIsCaptionEnabled] = useState(true);
+    const scrollYRef = useRef<number>(0);
+
+    useEffect(() => {
+        if (isOpen) {
+            scrollYRef.current = window.scrollY;
+
+            document.body.style.position = 'fixed';
+            document.body.style.top = `-${scrollYRef.current}px`;
+            document.body.style.left = '0';
+            document.body.style.right = '0';
+            document.body.style.overflow = 'hidden';
+        } else {
+            setTimeout(() => {
+                document.body.style.position = '';
+                document.body.style.top = '';
+                document.body.style.left = '';
+                document.body.style.right = '';
+                document.body.style.overflow = '';
+                window.scrollTo(0, scrollYRef.current);
+            }, 0);
+        }
+    }, [isOpen]);
 
     const slides = useMemo(() => arts.map(
         ({ image: { base64, mimeType }, description, title }, index) => {
-          let src = base64ToUrl(base64, mimeType);
-          if (!src) {
-            src = ''; //replace with default src
-          }
+            let src = base64ToUrl(base64, mimeType);
+            if (!src) {
+                src = '';
+            }
 
-          return {
-            src,
-            title: `${index + 1}/${arts.length}`,
-            description: <TitleDescriptionComponent title={title} description={description} />
-          };
+            return {
+                src,
+                title: `${index + 1}/${arts.length}`,
+                description: <TitleDescriptionComponent title={title} description={description} />,
+            };
         }
-      ), [arts]);
-      
+    ), [arts]);
 
-  const currentArtIndex = useMemo(() => arts.findIndex(
-    (art) => art.id === fromCardId,
-  ), [mutationObserved, fromCardId]);
+    const currentArtIndex = useMemo(() =>
+        arts.findIndex((art) => art.id === fromCardId),
+        [mutationObserved, fromCardId]
+    );
 
-  const onIdleTimerHandlers = useMemo(() => ({
-    onIdle: () => setIsCaptionEnabled(false),
-    onActive: () => setIsCaptionEnabled(true),
-  }), []);
+    const onIdleTimerHandlers = useMemo(() => ({
+        onIdle: () => setIsCaptionEnabled(false),
+        onActive: () => setIsCaptionEnabled(true),
+    }), []);
 
-  useIdleTimer({
-    ...onIdleTimerHandlers,
-    timeout: 3_000,
-  });
+    useIdleTimer({
+        ...onIdleTimerHandlers,
+        timeout: 3_000,
+    });
 
-  return (
-    <Lightbox
-      open={isOpen}
-      close={() => setModal('artGallery')}
-      index={currentArtIndex}
-      className={`lightbox ${!isCaptionEnabled ? 'lightboxDisabled' : ''}`}
-      slides={slides}
-      plugins={[Captions]}
-    />
-  );
+    return (
+        <Lightbox
+            open={isOpen}
+            close={() => setModal('artGallery')}
+            index={currentArtIndex}
+            className={`lightbox ${!isCaptionEnabled ? 'lightboxDisabled' : ''}`}
+            slides={slides}
+            plugins={[Captions]}
+        />
+    );
 };
 
 export default observer(LightboxComponent);


### PR DESCRIPTION
dev
## JIRA

* [2698](https://github.com/orgs/ita-social-projects/projects/21/views/10?filterQuery=-status%3A%22%F0%9F%A4%94+Clarifications%22%2C%22Test+cases+Pass%22%2C%22Test+Cases%22%2CImprovements%2CRequirements%2C%F0%9F%90%9EBugs%2CQC%2C%22%F0%9F%93%8B+Backlog%22%2C+sprint%3A%40current&sliceBy%5Bvalue%5D=ihor-yatsyshyn&pane=issue&itemId=107595576&issue=ita-social-projects%7CStreetCode%7C2698)

## Summary of issue

After closing Art Gallery full screen mode art, page moves to the top and the main image blinks from the left to the right

## Summary of change

Added hook so after closing full-screen art the main page stays in the same scroll position

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Prevents background scrolling when the lightbox modal is open and restores the previous scroll position when closed for an improved user experience.

- **Style**
  - Improved code formatting for better readability (no impact on functionality).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->