### PR TITLE
feature/issue-2595

### DIFF
--- a/src/features/StreetcodePage/TextBlock/ReadMore/ReadMore.styles.scss
+++ b/src/features/StreetcodePage/TextBlock/ReadMore/ReadMore.styles.scss
@@ -4,7 +4,8 @@
 
 .text {
     white-space: pre-wrap;
-    word-break: break-all;
+    word-break: normal;
+    overflow-wrap: break-word;
     width: 100%;
 
     ul {


### PR DESCRIPTION
dev
## JIRA

https://github.com/orgs/ita-social-projects/projects/21/views/1?pane=issue&itemId=103018250&issue=ita-social-projects%7CStreetCode%7C2595

## Summary of issue

The main text block of the street code should not contain any syllable divisions.

## Summary of change

Changed the styles of the main text block, word breaks are disabled


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved text wrapping for better readability in text blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->