### PR TITLE
Fixed bug with showing profile data from previous logged in user

### DIFF
--- a/src/app/common/services/auth-service/AuthService.ts
+++ b/src/app/common/services/auth-service/AuthService.ts
@@ -38,6 +38,7 @@ export default class AuthService {
 
     public static logout() {
         this.clearTokenData();
+        window.location.reload();
     }
 
     public static loginAsync(

--- a/src/app/stores/streetcode-text-video-store.ts
+++ b/src/app/stores/streetcode-text-video-store.ts
@@ -17,7 +17,9 @@ export default class TextVideoStore {
 
     public fetchStreetcodeText = async (id: number): Promise<Text> => {
         const text = await TextsApi.getByStreetcodeId(id);
-        text.textContent = await TextsApi.updateParsed(text);
+        if (text) {
+            text.textContent = await TextsApi.updateParsed(text);
+        }
         this.Text = text;
         return text;
     };


### PR DESCRIPTION
dev

## Summary of issue

After changing account we could see profile data of previous logged in user

## Summary of change

Added refresh page on log out + fixed a bug with null check on loading streetcodes

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Logging out now automatically refreshes the page, ensuring the application state is fully reset after logout.
- **Bug Fixes**
  - Improved stability by preventing errors when fetching and updating text content if data is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->